### PR TITLE
Make filter aware of changes in cache (11794)

### DIFF
--- a/OpenStack Summit/OpenStack Summit/EventsViewController.swift
+++ b/OpenStack Summit/OpenStack Summit/EventsViewController.swift
@@ -29,7 +29,7 @@ final class EventsViewController: RevealTabStripViewController, ShowActivityIndi
             filterButton?.tintColor = activeFilterIndicator ? UIColor(hexaString: "#F8E71C") : UIColor.whiteColor()
             navigationController?.toolbar.barTintColor = UIColor(hexaString: "#F8E71C")
             navigationController?.toolbar.translucent = false
-            navigationController?.setToolbarHidden(!activeFilterIndicator, animated: true)
+            navigationController?.setToolbarHidden(!activeFilterIndicator, animated: !activeFilterIndicator)
         }
     }
     

--- a/OpenStack Summit/OpenStack Summit/Filter.swift
+++ b/OpenStack Summit/OpenStack Summit/Filter.swift
@@ -168,11 +168,24 @@ struct ScheduleFilter: Equatable {
     
     // MARK: - Properties
     
-    var selections = [FilterSectionType: FilterSelection]()
+    var selections = [FilterSectionType: FilterSelection]() {
+        
+        didSet {
+            
+            var oldFilter = self
+            oldFilter.selections = oldValue
+            let wasHidingPastTalks = oldFilter.shoudHidePastTalks()
+            
+            if shoudHidePastTalks() != wasHidingPastTalks {
+                
+                didChangeActiveTalks = true
+            }
+        }
+    }
     var filterSections = [FilterSection]()
     
     /// Whether a selection has been made in the `Active Talks` filters.
-    var didChangeActiveTalks = false
+    private(set) var didChangeActiveTalks = false
     
     // MARK: - Initialization
     

--- a/OpenStack Summit/OpenStack Summit/Filter.swift
+++ b/OpenStack Summit/OpenStack Summit/Filter.swift
@@ -14,7 +14,7 @@ enum FilterSectionType {
     case ActiveTalks, EventType, Track, TrackGroup, Tag, Level, Venue
 }
 
-struct FilterSection {
+struct FilterSection: Equatable {
     var type: FilterSectionType
     var name: String
     var items: [FilterSectionItem]
@@ -27,13 +27,26 @@ struct FilterSection {
     }
 }
 
-struct FilterSectionItem: Unique, Named {
+func == (lhs: FilterSection, rhs: FilterSection) -> Bool {
+    
+    return lhs.type == rhs.type
+        && lhs.name == rhs.name
+        && lhs.items == rhs.items
+}
+
+struct FilterSectionItem: Unique, Named, Equatable {
     
     let identifier: Identifier
     let name: String
 }
 
-enum FilterSelection: RawRepresentable {
+func == (lhs: FilterSectionItem, rhs: FilterSectionItem) -> Bool {
+    
+    return lhs.identifier == rhs.identifier
+        && lhs.name == rhs.name
+}
+
+enum FilterSelection: RawRepresentable, Equatable {
     
     case identifiers([Identifier])
     case names([String])
@@ -142,7 +155,16 @@ enum FilterSelection: RawRepresentable {
     }
 }
 
-struct ScheduleFilter {
+func == (lhs: FilterSelection, rhs: FilterSelection) -> Bool {
+    
+    switch (lhs, rhs) {
+    case let (.identifiers(lhsValues), .identifiers(rhsValues)): return lhsValues == rhsValues
+    case let (.names(lhsValues), .names(rhsValues)): return lhsValues == rhsValues
+    default: return false
+    }
+}
+
+struct ScheduleFilter: Equatable {
     
     // MARK: - Properties
     
@@ -240,15 +262,14 @@ struct ScheduleFilter {
             let startDate = summit.start.toFoundation().mt_dateSecondsAfter(summitTimeZoneOffset).mt_startOfCurrentDay()
             let endDate = summit.end.toFoundation().mt_dateSecondsAfter(summitTimeZoneOffset).mt_dateDaysAfter(1)
             let now = NSDate()
-            
-            let activeTalksFilters = ["Hide Past Talks"]
-            
+                        
             if now.mt_isBetweenDate(startDate, andDate: endDate) {
                 
                 // dont want to override selection
                 if didChangeActiveTalks == false {
                     
-                    selections[FilterSectionType.ActiveTalks] = .names(activeTalksFilters) // Active Talks filters are static
+                    // start hiding active talks
+                    selections[FilterSectionType.ActiveTalks] = .names(["Hide Past Talks"])
                 }
             }
             else {
@@ -299,6 +320,13 @@ struct ScheduleFilter {
     }
 }
 
+func == (lhs: ScheduleFilter, rhs: ScheduleFilter) -> Bool {
+    
+    return lhs.selections == rhs.selections
+        && lhs.filterSections == rhs.filterSections
+        && lhs.didChangeActiveTalks == rhs.didChangeActiveTalks
+}
+
 // MARK: - Manager
 
 final class FilterManager {
@@ -323,7 +351,7 @@ final class FilterManager {
         
         notificationToken = Store.shared.realm.addNotificationBlock { [weak self] _,_ in self?.filter.value.updateSections() }
         
-        timer = NSTimer.scheduledTimerWithTimeInterval(30, target: self, selector: #selector(timerUpdate), userInfo: nil, repeats: true)
+        timer = NSTimer.scheduledTimerWithTimeInterval(10, target: self, selector: #selector(timerUpdate), userInfo: nil, repeats: true)
     }
     
     @objc private func timerUpdate(sender: NSTimer) {

--- a/OpenStack Summit/OpenStack Summit/GeneralScheduleFilterViewController.swift
+++ b/OpenStack Summit/OpenStack Summit/GeneralScheduleFilterViewController.swift
@@ -259,12 +259,6 @@ final class GeneralScheduleFilterViewController: UIViewController, UITableViewDe
                 FilterManager.shared.filter.value.selections[filterSection.type]!.append(filterItem.name)
                 cell.isOptionSelected = true
             }
-            
-        fallthrough
-            
-        case .ActiveTalks:
-            
-            FilterManager.shared.filter.value.didChangeActiveTalks = true
         }
     }
     

--- a/OpenStack Summit/OpenStack Summit/GeneralScheduleFilterViewController.swift
+++ b/OpenStack Summit/OpenStack Summit/GeneralScheduleFilterViewController.swift
@@ -86,6 +86,8 @@ final class GeneralScheduleFilterViewController: UIViewController, UITableViewDe
             selector: #selector(AMTagListView.removeTag(_:)),
             name: AMTagViewNotification,
             object: nil)
+        
+        FilterManager.shared.filter.value.updateSections()
     }
     
     override func viewWillDisappear(animated: Bool) {
@@ -126,6 +128,7 @@ final class GeneralScheduleFilterViewController: UIViewController, UITableViewDe
         }
     }
     
+    @inline(__always)
     private func reloadFilters() {
         
         let scheduleFilter = FilterManager.shared.filter.value
@@ -227,7 +230,9 @@ final class GeneralScheduleFilterViewController: UIViewController, UITableViewDe
         
         let filterItem = filterSection.items[index]
         
-        if filterSection.type != FilterSectionType.Level && filterSection.type != FilterSectionType.ActiveTalks {
+        switch filterSection.type {
+            
+        case .EventType, .Tag, .Track, .TrackGroup, .Venue:
             
             if isItemSelected(filterSection.type, id: filterItem.identifier) {
                 
@@ -240,8 +245,8 @@ final class GeneralScheduleFilterViewController: UIViewController, UITableViewDe
                 FilterManager.shared.filter.value.selections[filterSection.type]!.append(filterItem.identifier)
                 cell.isOptionSelected = true
             }
-        }
-        else {
+            
+        case .Level, .ActiveTalks:
             
             if isItemSelected(filterSection.type, name: filterItem.name) {
                 
@@ -254,9 +259,10 @@ final class GeneralScheduleFilterViewController: UIViewController, UITableViewDe
                 FilterManager.shared.filter.value.selections[filterSection.type]!.append(filterItem.name)
                 cell.isOptionSelected = true
             }
-        }
-        
-        if filterSection.type == FilterSectionType.ActiveTalks {
+            
+        fallthrough
+            
+        case .ActiveTalks:
             
             FilterManager.shared.filter.value.didChangeActiveTalks = true
         }

--- a/OpenStack Summit/OpenStack Summit/Observable.swift
+++ b/OpenStack Summit/OpenStack Summit/Observable.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2016 OpenStack. All rights reserved.
 //
 
-public final class Observable<Value> {
+public final class Observable<Value: Equatable> {
     
     // MARK: - Properties
     
@@ -14,7 +14,10 @@ public final class Observable<Value> {
         
         didSet {
             
-            observers.forEach { $0.callback(value) }
+            if value != oldValue {
+                
+                observers.forEach { $0.callback(value) }
+            }
         }
     }
     

--- a/OpenStack Summit/OpenStack Summit/ScheduleViewController.swift
+++ b/OpenStack Summit/OpenStack Summit/ScheduleViewController.swift
@@ -432,6 +432,11 @@ class ScheduleViewController: UIViewController, MessageEnabledViewController, Sh
     func horizontalDayPicker(picker: AFHorizontalDayPicker, didSelectDate date: NSDate) {
         
         reloadSchedule()
+        
+        if dayEvents.isEmpty == false {
+            
+            self.scheduleView.tableView.selectRowAtIndexPath(NSIndexPath(forRow: 0, inSection: 0), animated: true, scrollPosition: .Top)
+        }
     }
     
     // MARK: - UITableViewDataSource

--- a/OpenStack Summit/OpenStack Summit/ScheduleViewController.swift
+++ b/OpenStack Summit/OpenStack Summit/ScheduleViewController.swift
@@ -105,7 +105,7 @@ class ScheduleViewController: UIViewController, MessageEnabledViewController, Sh
         realmNotificationToken = Store.shared.realm.addNotificationBlock { (_, _) in self.reloadSchedule() }
         
         // filter notifications
-        filterObserver = FilterManager.shared.filter.observe { _ in let _ = self.view; self.reloadSchedule() }
+        filterObserver = FilterManager.shared.filter.observe { _ in self.filterUpdated() }
     }
     
     // MARK: - Actions
@@ -269,8 +269,19 @@ class ScheduleViewController: UIViewController, MessageEnabledViewController, Sh
         let today = NSDate()
         
         let shoudHidePastTalks = scheduleFilter.shoudHidePastTalks()
+        
+        let dailyScheduleStartDate: NSDate
+        
+        if shoudHidePastTalks {
+            
+            dailyScheduleStartDate = startDate.mt_isAfter(today) ? startDate : today
+            
+        } else {
+            
+            dailyScheduleStartDate = startDate
+        }
 
-        self.dayEvents = self.scheduledEvents(from: shoudHidePastTalks ? today : startDate, to: endDate)
+        self.dayEvents = self.scheduledEvents(from: dailyScheduleStartDate, to: endDate)
         
         if oldSchedule.isEmpty {
             
@@ -355,17 +366,17 @@ class ScheduleViewController: UIViewController, MessageEnabledViewController, Sh
         }
     }
     
-    private final func isDataLoaded() -> Bool {
+    private func isDataLoaded() -> Bool {
         
         return Store.shared.realm.objects(RealmSummit.self).first != nil
     }
 
-    private final func eventExist(id: Identifier) -> Bool {
+    private func eventExist(id: Identifier) -> Bool {
         
         return RealmSummitEvent.find(id, realm: Store.shared.realm) != nil
     }
     
-    private final func configure(cell cell: ScheduleTableViewCell, at indexPath: NSIndexPath) {
+    private func configure(cell cell: ScheduleTableViewCell, at indexPath: NSIndexPath) {
         
         let index = indexPath.row
         let event = dayEvents[index]
@@ -385,6 +396,25 @@ class ScheduleViewController: UIViewController, MessageEnabledViewController, Sh
         cell.separatorInset = UIEdgeInsetsZero
         cell.layoutMargins = UIEdgeInsetsZero
         cell.layoutSubviews()
+    }
+    
+    private func filterUpdated() {
+        
+        // force view load
+        let _ = self.view
+        
+        let oldSelection = self.selectedDate
+        
+        self.loadData()
+        
+        if let firstDate = availableDates.first where firstDate.mt_isAfter(oldSelection) {
+            
+            self.selectedDate = firstDate
+            
+        } else {
+            
+            self.selectedDate = oldSelection
+        }
     }
     
     // MARK: - AFHorizontalDayPickerDelegate


### PR DESCRIPTION
Currently filter are statically created and shared across view controllers that use it; not being aware of data changes in the cache.
Say we get a data update adding one event to a track, that track won't show in filters.
We need to make filters aware of changes in model data.