### PR TITLE
[CoreSummit] Fixes environment setting in oauth accounts initialization.

### DIFF
--- a/OpenStack Summit/CoreSummit/Store.swift
+++ b/OpenStack Summit/CoreSummit/Store.swift
@@ -54,7 +54,9 @@ public final class Store {
     
     #endif
     
-    public var environment = Environment.Staging
+    public var environment = Environment.Staging {
+        didSet { configOAuthAccounts() }
+    }
     
     public var session: SessionStorage? {
         
@@ -80,12 +82,11 @@ public final class Store {
     // MARK: - Initialization
     
     deinit {
+        
         NSNotificationCenter.defaultCenter().removeObserver(self)
     }
     
     private init() {
-        
-        configOAuthAccounts()
         
         NSNotificationCenter.defaultCenter().removeObserver(self, name: OAuth2Module.revokeNotification, object: nil)
         NSNotificationCenter.defaultCenter().addObserver(


### PR DESCRIPTION
Setting shared Store's environment in app delegate caused Store singleton to initialize, configuring OAuth account's with singleton's default environment setting.
This PR configures OAuth account once that environment is set.