### PR TITLE
[11915] Discard and log failed data update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,9 +45,8 @@ DeployBeta.sh
 
 OpenStack Summit/CoreSummit/Staging.swift
 OpenStack Summit/CoreSummit/Production.swift
-
 OpenStack Summit/OpenStack Summit/AppConsumerKey.swift
-
 OpenStack Summit/Release.entitlements
 OpenStack Summit/Debug.entitlements
 OpenStack Summit/Beta.entitlements
+OpenStack Summit/FabricInfoPlist.swift

--- a/OpenStack Summit/CoreSummit/DataUpdatePoller.swift
+++ b/OpenStack Summit/CoreSummit/DataUpdatePoller.swift
@@ -80,7 +80,9 @@ public final class DataUpdatePoller {
                         
                         // could not process update
                         
+                        #if os(iOS)
                         Crashlytics.sharedInstance().recordError(friendlyError)
+                        #endif
                         
                         print("Could not process data update: \(update)")
                     }
@@ -153,5 +155,3 @@ public final class UserDefaultsDataUpdatePollerStorage: DataUpdatePollerStorage 
         case LatestDataUpdate = "CoreSummit.UserDefaultsDataUpdatePollerStorage.Key.LatestDataUpdate"
     }
 }
-
-

--- a/OpenStack Summit/CoreSummit/DataUpdatePoller.swift
+++ b/OpenStack Summit/CoreSummit/DataUpdatePoller.swift
@@ -8,7 +8,11 @@
 
 import Foundation
 import SwiftFoundation
+
+#if os(iOS)
 import Crashlytics
+import Fabric
+#endif
 
 public final class DataUpdatePoller {
     
@@ -81,7 +85,11 @@ public final class DataUpdatePoller {
                         // could not process update
                         
                         #if os(iOS)
+                        
+                        let friendlyError = NSError(domain: "CoreSummit", code: -200, userInfo: [NSLocalizedDescriptionKey: "Could not process data update.", "DataUpdate": "\(update)"])
+                        
                         Crashlytics.sharedInstance().recordError(friendlyError)
+                        
                         #endif
                         
                         print("Could not process data update: \(update)")

--- a/OpenStack Summit/CoreSummit/DataUpdatePoller.swift
+++ b/OpenStack Summit/CoreSummit/DataUpdatePoller.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import SwiftFoundation
+import Crashlytics
 
 public final class DataUpdatePoller {
     
@@ -75,15 +76,13 @@ public final class DataUpdatePoller {
                 
                 for update in dataUpdates {
                     
-                    guard Store.shared.process(update) else {
+                    if Store.shared.process(update) == false {
                         
                         // could not process update
                         
-                        //Crashlytics.sharedInstance().recordError(friendlyError)
+                        Crashlytics.sharedInstance().recordError(friendlyError)
                         
                         print("Could not process data update: \(update)")
-                        
-                        return
                     }
                     
                     // store latest data update

--- a/OpenStack Summit/CoreSummit/DataUpdatePoller.swift
+++ b/OpenStack Summit/CoreSummit/DataUpdatePoller.swift
@@ -85,10 +85,20 @@ public final class DataUpdatePoller {
                         // could not process update
                         
                         #if os(iOS)
+                            
+                            var errorUserInfo = [NSLocalizedDescriptionKey: "Could not process data update.", "DataUpdate": "\(update)"]
+                            
+                            if let updateEntity = update.entity,
+                                case let .JSON(jsonObject) = updateEntity {
+                                
+                                let jsonString = JSON.Value.Object(jsonObject).toString()!
+                                
+                                errorUserInfo["JSON"] = jsonString
+                            }
                         
-                        let friendlyError = NSError(domain: "CoreSummit", code: -200, userInfo: [NSLocalizedDescriptionKey: "Could not process data update.", "DataUpdate": "\(update)"])
+                            let friendlyError = NSError(domain: "CoreSummit", code: -200, userInfo:errorUserInfo)
                         
-                        Crashlytics.sharedInstance().recordError(friendlyError)
+                            Crashlytics.sharedInstance().recordError(friendlyError)
                         
                         #endif
                         

--- a/OpenStack Summit/Export.plist
+++ b/OpenStack Summit/Export.plist
@@ -2,13 +2,13 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-        <key>teamID</key>
-        <string>775U6X6R5M</string>
-        <key>method</key>
-        <string>app-store</string>
-        <key>uploadSymbols</key>
-        <true/>
-        <key>uploadBitcode</key>
-        <false/>
+	<key>teamID</key>
+	<string>775U6X6R5M</string>
+	<key>method</key>
+	<string>app-store</string>
+	<key>uploadSymbols</key>
+	<true/>
+	<key>uploadBitcode</key>
+	<true/>
 </dict>
 </plist>

--- a/OpenStack Summit/FabricInfoPlist.swift.xctemplate
+++ b/OpenStack Summit/FabricInfoPlist.swift.xctemplate
@@ -25,7 +25,7 @@ func integrateFabric() {
     // modify
     var infoPlist = currentInfoPlist
     
-    let kit = ["KitInfo": ["KitName": "Crashlytics"]]
+    let kit = ["KitInfo": [:], "KitName": "Crashlytics"]
     
     var fabric = [String: AnyObject]()
     fabric["APIKey"] = FabricAPIKey as NSString

--- a/OpenStack Summit/FabricInfoPlist.swift.xctemplate
+++ b/OpenStack Summit/FabricInfoPlist.swift.xctemplate
@@ -1,0 +1,41 @@
+#!/usr/bin/env xcrun swift
+
+import Foundation
+
+let FabricAPIKey = "Fabric API Key"
+
+func currentInfoPist() -> (String, [String: AnyObject])? {
+    
+    guard Process.arguments.count == 2
+        else { print("Must specify Info.plist path"); return nil }
+				
+    let infoPlistPath = Process.arguments[1]
+    
+    guard let infoPlist = NSDictionary(contentsOfFile: infoPlistPath) as? [String: AnyObject]
+        else { print("Could not parse file"); return nil }
+    
+    return (infoPlistPath, infoPlist)
+}
+
+func integrateFabric() {
+    
+    guard let (infoPlistPath, currentInfoPlist) = currentInfoPist()
+        else { return }
+    
+    // modify
+    var infoPlist = currentInfoPlist
+    
+    let kit = ["KitInfo": ["KitName": "Crashlytics"]]
+    
+    var fabric = [String: AnyObject]()
+    fabric["APIKey"] = FabricAPIKey as NSString
+    fabric["Kits"] = [kit] as NSArray
+    
+    infoPlist["Fabric"] = fabric as NSDictionary
+    
+    // write
+    guard (infoPlist as NSDictionary).writeToFile(infoPlistPath, atomically: true)
+        else { print("Could not write to file"); return }
+}
+
+integrateFabric()

--- a/OpenStack Summit/OpenStack Summit.xcodeproj/project.pbxproj
+++ b/OpenStack Summit/OpenStack Summit.xcodeproj/project.pbxproj
@@ -298,7 +298,6 @@
 		6E2923F51D7AF8C900D14F0A /* RealmTicketType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E10A5431D10675C008CBD0C /* RealmTicketType.swift */; };
 		6E2923F61D7AF8C900D14F0A /* EventJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E10A51E1D10675C008CBD0C /* EventJSON.swift */; };
 		6E2923F71D7AF8C900D14F0A /* RealmTrackGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E10A5451D10675C008CBD0C /* RealmTrackGroup.swift */; };
-		6E2923F81D7AF8C900D14F0A /* DataUpdatePoller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EDAF38D1D5BB22700B75B28 /* DataUpdatePoller.swift */; };
 		6E2923F91D7AF8C900D14F0A /* Location.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E10A5261D10675C008CBD0C /* Location.swift */; };
 		6E2923FA1D7AF8C900D14F0A /* RealmSummitEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E10A5401D10675C008CBD0C /* RealmSummitEvent.swift */; };
 		6E2923FB1D7AF8C900D14F0A /* DataUpdateRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E25291D1D58E6F200173B1F /* DataUpdateRequest.swift */; };
@@ -432,6 +431,8 @@
 		6EA6FD381D958512009B66B0 /* DetailImageTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 6EA6FD361D958512009B66B0 /* DetailImageTableViewCell.xib */; };
 		6EAEF7CD1D2C67A700079995 /* GeneralScheduleFilterTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EAEF7CB1D2C67A700079995 /* GeneralScheduleFilterTableViewCell.swift */; };
 		6EAEF7CE1D2C67A700079995 /* GeneralScheduleFilterTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 6EAEF7CC1D2C67A700079995 /* GeneralScheduleFilterTableViewCell.xib */; };
+		6EB295171DA97B0B0021C846 /* Crashlytics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6EB295161DA97B0B0021C846 /* Crashlytics.framework */; };
+		6EB2951A1DA97B230021C846 /* Crashlytics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6EB295161DA97B0B0021C846 /* Crashlytics.framework */; };
 		6EB3EA0D1D1B5158000BA5A4 /* TableViewHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EB3EA091D1B5158000BA5A4 /* TableViewHeaderView.swift */; };
 		6EB3EA0E1D1B5158000BA5A4 /* TableViewHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 6EB3EA0A1D1B5158000BA5A4 /* TableViewHeaderView.xib */; };
 		6EB3EA101D1B5158000BA5A4 /* FeedbackTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 6EB3EA0C1D1B5158000BA5A4 /* FeedbackTableViewCell.xib */; };
@@ -898,6 +899,7 @@
 		6E6FD1761D7A1A15003D13D7 /* Production.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Production.swift; sourceTree = "<group>"; };
 		6E6FD1781D7A1A20003D13D7 /* Staging.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Staging.swift; sourceTree = "<group>"; };
 		6E6FD17E1D7A1CA2003D13D7 /* AppConsumerKey.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppConsumerKey.swift; sourceTree = "<group>"; };
+		6E72BCBE1DA97E42002E1BA9 /* FabricInfoPlist.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FabricInfoPlist.swift; sourceTree = "<group>"; };
 		6E730B8C1DA2E254005E486B /* Page.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Page.swift; sourceTree = "<group>"; };
 		6E730B8E1DA2E405005E486B /* PageJSON.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PageJSON.swift; sourceTree = "<group>"; };
 		6E74FAEC1D7C962B0018633D /* EventDatesViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventDatesViewController.swift; sourceTree = "<group>"; };
@@ -937,6 +939,7 @@
 		6EA6FD361D958512009B66B0 /* DetailImageTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = DetailImageTableViewCell.xib; sourceTree = "<group>"; };
 		6EAEF7CB1D2C67A700079995 /* GeneralScheduleFilterTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeneralScheduleFilterTableViewCell.swift; sourceTree = "<group>"; };
 		6EAEF7CC1D2C67A700079995 /* GeneralScheduleFilterTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = GeneralScheduleFilterTableViewCell.xib; sourceTree = "<group>"; };
+		6EB295161DA97B0B0021C846 /* Crashlytics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Crashlytics.framework; sourceTree = "<group>"; };
 		6EB3EA091D1B5158000BA5A4 /* TableViewHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableViewHeaderView.swift; sourceTree = "<group>"; };
 		6EB3EA0A1D1B5158000BA5A4 /* TableViewHeaderView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = TableViewHeaderView.xib; sourceTree = "<group>"; };
 		6EB3EA0B1D1B5158000BA5A4 /* FeedbackTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FeedbackTableViewCell.swift; sourceTree = "<group>"; };
@@ -1072,6 +1075,7 @@
 				6EDE521B1D42D46400DF4BEA /* AVFoundation.framework in Frameworks */,
 				6EDE52191D42D09D00DF4BEA /* GoogleMaps.framework in Frameworks */,
 				6E10A5061D1066E9008CBD0C /* CoreSummit.framework in Frameworks */,
+				6EB295171DA97B0B0021C846 /* Crashlytics.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1093,6 +1097,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6EB2951A1DA97B230021C846 /* Crashlytics.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1168,6 +1173,7 @@
 			isa = PBXGroup;
 			children = (
 				6EA1F0891D660B550064C338 /* Cartfile */,
+				6E72BCBE1DA97E42002E1BA9 /* FabricInfoPlist.swift */,
 				6E104D301D1061AC00541E84 /* OpenStack Summit */,
 				6E104D451D1061AC00541E84 /* OpenStack SummitTests */,
 				6E104D501D1061AC00541E84 /* OpenStack SummitUITests */,
@@ -1667,6 +1673,7 @@
 		6EDE52161D42D08200DF4BEA /* Vendor */ = {
 			isa = PBXGroup;
 			children = (
+				6EB295161DA97B0B0021C846 /* Crashlytics.framework */,
 				6E24FDE31D47CE290005EB14 /* GoogleMaps.bundle */,
 				6EDE52171D42D08200DF4BEA /* GoogleMaps.framework */,
 			);
@@ -1915,6 +1922,7 @@
 				6E10A50D1D1066E9008CBD0C /* Embed Frameworks */,
 				6EF12C5C1D149A8E00814AD0 /* Copy Frameworks */,
 				6EF12C5D1D149B2300814AD0 /* Increment Build */,
+				6E72BCBF1DA97F05002E1BA9 /* Integrate Fabric */,
 				6E40E1371D7A2F200025D74E /* Increment WatchOS Build */,
 				6E0B5F771D77D4DF0005F6CE /* Embed Watch Content */,
 			);
@@ -2343,6 +2351,20 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/usr/local/bin/carthage copy-frameworks";
+		};
+		6E72BCBF1DA97F05002E1BA9 /* Integrate Fabric */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Integrate Fabric";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "echo \"Integrating Fabric into Info.plist\"\n$(SRCROOT)/FabricInfoPlist.swift \"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}\"\n";
 		};
 		6E74FB051D7CB01F0018633D /* Increment Build */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -2884,7 +2906,6 @@
 				6E2923F51D7AF8C900D14F0A /* RealmTicketType.swift in Sources */,
 				6E2923F61D7AF8C900D14F0A /* EventJSON.swift in Sources */,
 				6E2923F71D7AF8C900D14F0A /* RealmTrackGroup.swift in Sources */,
-				6E2923F81D7AF8C900D14F0A /* DataUpdatePoller.swift in Sources */,
 				6E2923F91D7AF8C900D14F0A /* Location.swift in Sources */,
 				6E2923FA1D7AF8C900D14F0A /* RealmSummitEvent.swift in Sources */,
 				6E2923FB1D7AF8C900D14F0A /* DataUpdateRequest.swift in Sources */,
@@ -3440,6 +3461,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					$SRCROOT/../Carthage/Build/iOS,
+					$SRCROOT/../Vendor,
+				);
 				INFOPLIST_FILE = CoreSummit/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				OTHER_SWIFT_FLAGS = "-D DEBUG -D CORESUMMITREALM";
@@ -3463,6 +3488,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					$SRCROOT/../Carthage/Build/iOS,
+					$SRCROOT/../Vendor,
+				);
 				INFOPLIST_FILE = CoreSummit/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				OTHER_SWIFT_FLAGS = "-D CORESUMMITREALM";
@@ -3709,6 +3738,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					$SRCROOT/../Carthage/Build/iOS,
+					$SRCROOT/../Vendor,
+				);
 				INFOPLIST_FILE = CoreSummit/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				OTHER_SWIFT_FLAGS = "-D CORESUMMITREALM";

--- a/OpenStack Summit/OpenStack Summit.xcodeproj/project.pbxproj
+++ b/OpenStack Summit/OpenStack Summit.xcodeproj/project.pbxproj
@@ -417,6 +417,8 @@
 		6E9B22D41D3FE33500D25271 /* TrackScheduleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E9B22D31D3FE33500D25271 /* TrackScheduleViewController.swift */; };
 		6E9B22D61D400B8A00D25271 /* LevelScheduleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E9B22D51D400B8A00D25271 /* LevelScheduleViewController.swift */; };
 		6E9B22D81D40171800D25271 /* Venue.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6E9B22D71D40171800D25271 /* Venue.storyboard */; };
+		6E9CB32D1DAD6DDD00FCD859 /* Fabric.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6E9CB32C1DAD6DDD00FCD859 /* Fabric.framework */; };
+		6E9CB32E1DAD6DDD00FCD859 /* Fabric.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6E9CB32C1DAD6DDD00FCD859 /* Fabric.framework */; };
 		6E9CDB041D7E72760010D1E1 /* EventDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E4905501D2EE04F00D56870 /* EventDetail.swift */; };
 		6E9CDB051D7E72830010D1E1 /* ScheduleItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E10A5A41D106AD5008CBD0C /* ScheduleItem.swift */; };
 		6E9CDB061D7E72B60010D1E1 /* SummitEventExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E10A5A61D106AD5008CBD0C /* SummitEventExtensions.swift */; };
@@ -927,6 +929,7 @@
 		6E9B22D31D3FE33500D25271 /* TrackScheduleViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrackScheduleViewController.swift; sourceTree = "<group>"; };
 		6E9B22D51D400B8A00D25271 /* LevelScheduleViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LevelScheduleViewController.swift; sourceTree = "<group>"; };
 		6E9B22D71D40171800D25271 /* Venue.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Venue.storyboard; sourceTree = "<group>"; };
+		6E9CB32C1DAD6DDD00FCD859 /* Fabric.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Fabric.framework; sourceTree = "<group>"; };
 		6E9CDB021D7E6DF00010D1E1 /* EventDetailViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventDetailViewController.swift; sourceTree = "<group>"; };
 		6E9F28EF1D7C903E002B7C7A /* OpenStackSummitTV.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = OpenStackSummitTV.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		6E9F28F11D7C903E002B7C7A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -1064,6 +1067,7 @@
 				6EDE52321D42D50000DF4BEA /* libz.tbd in Frameworks */,
 				6EDE52301D42D4F600DF4BEA /* libicucore.tbd in Frameworks */,
 				6EDE522E1D42D4EB00DF4BEA /* libc++.tbd in Frameworks */,
+				6E9CB32D1DAD6DDD00FCD859 /* Fabric.framework in Frameworks */,
 				6EDE522C1D42D4D600DF4BEA /* ImageIO.framework in Frameworks */,
 				6EDE52251D42D4C700DF4BEA /* CoreGraphics.framework in Frameworks */,
 				6EDE52261D42D4C700DF4BEA /* CoreLocation.framework in Frameworks */,
@@ -1098,6 +1102,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				6EB2951A1DA97B230021C846 /* Crashlytics.framework in Frameworks */,
+				6E9CB32E1DAD6DDD00FCD859 /* Fabric.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1673,6 +1678,7 @@
 		6EDE52161D42D08200DF4BEA /* Vendor */ = {
 			isa = PBXGroup;
 			children = (
+				6E9CB32C1DAD6DDD00FCD859 /* Fabric.framework */,
 				6EB295161DA97B0B0021C846 /* Crashlytics.framework */,
 				6E24FDE31D47CE290005EB14 /* GoogleMaps.bundle */,
 				6EDE52171D42D08200DF4BEA /* GoogleMaps.framework */,
@@ -2364,7 +2370,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "echo \"Integrating Fabric into Info.plist\"\n$(SRCROOT)/FabricInfoPlist.swift \"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}\"\n";
+			shellScript = "echo \"Integrating Fabric into Info.plist\"\n\"${SRCROOT}/FabricInfoPlist.swift\" \"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}\"\n";
 		};
 		6E74FB051D7CB01F0018633D /* Increment Build */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/OpenStack Summit/OpenStack Summit.xcodeproj/project.pbxproj
+++ b/OpenStack Summit/OpenStack Summit.xcodeproj/project.pbxproj
@@ -417,7 +417,6 @@
 		6E9B22D41D3FE33500D25271 /* TrackScheduleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E9B22D31D3FE33500D25271 /* TrackScheduleViewController.swift */; };
 		6E9B22D61D400B8A00D25271 /* LevelScheduleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E9B22D51D400B8A00D25271 /* LevelScheduleViewController.swift */; };
 		6E9B22D81D40171800D25271 /* Venue.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6E9B22D71D40171800D25271 /* Venue.storyboard */; };
-		6E9CB32D1DAD6DDD00FCD859 /* Fabric.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6E9CB32C1DAD6DDD00FCD859 /* Fabric.framework */; };
 		6E9CB32E1DAD6DDD00FCD859 /* Fabric.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6E9CB32C1DAD6DDD00FCD859 /* Fabric.framework */; };
 		6E9CDB041D7E72760010D1E1 /* EventDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E4905501D2EE04F00D56870 /* EventDetail.swift */; };
 		6E9CDB051D7E72830010D1E1 /* ScheduleItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E10A5A41D106AD5008CBD0C /* ScheduleItem.swift */; };
@@ -433,7 +432,6 @@
 		6EA6FD381D958512009B66B0 /* DetailImageTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 6EA6FD361D958512009B66B0 /* DetailImageTableViewCell.xib */; };
 		6EAEF7CD1D2C67A700079995 /* GeneralScheduleFilterTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EAEF7CB1D2C67A700079995 /* GeneralScheduleFilterTableViewCell.swift */; };
 		6EAEF7CE1D2C67A700079995 /* GeneralScheduleFilterTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 6EAEF7CC1D2C67A700079995 /* GeneralScheduleFilterTableViewCell.xib */; };
-		6EB295171DA97B0B0021C846 /* Crashlytics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6EB295161DA97B0B0021C846 /* Crashlytics.framework */; };
 		6EB2951A1DA97B230021C846 /* Crashlytics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6EB295161DA97B0B0021C846 /* Crashlytics.framework */; };
 		6EB3EA0D1D1B5158000BA5A4 /* TableViewHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EB3EA091D1B5158000BA5A4 /* TableViewHeaderView.swift */; };
 		6EB3EA0E1D1B5158000BA5A4 /* TableViewHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 6EB3EA0A1D1B5158000BA5A4 /* TableViewHeaderView.xib */; };
@@ -680,16 +678,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		6E29240B1D7AF8C900D14F0A /* Copy Configurations */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = Configuration;
-			dstSubfolderSpec = 7;
-			files = (
-			);
-			name = "Copy Configurations";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		6E3B98A61D4A6840009B4926 /* Copy Configurations */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = Configuration;
@@ -1067,7 +1055,6 @@
 				6EDE52321D42D50000DF4BEA /* libz.tbd in Frameworks */,
 				6EDE52301D42D4F600DF4BEA /* libicucore.tbd in Frameworks */,
 				6EDE522E1D42D4EB00DF4BEA /* libc++.tbd in Frameworks */,
-				6E9CB32D1DAD6DDD00FCD859 /* Fabric.framework in Frameworks */,
 				6EDE522C1D42D4D600DF4BEA /* ImageIO.framework in Frameworks */,
 				6EDE52251D42D4C700DF4BEA /* CoreGraphics.framework in Frameworks */,
 				6EDE52261D42D4C700DF4BEA /* CoreLocation.framework in Frameworks */,
@@ -1079,7 +1066,6 @@
 				6EDE521B1D42D46400DF4BEA /* AVFoundation.framework in Frameworks */,
 				6EDE52191D42D09D00DF4BEA /* GoogleMaps.framework in Frameworks */,
 				6E10A5061D1066E9008CBD0C /* CoreSummit.framework in Frameworks */,
-				6EB295171DA97B0B0021C846 /* Crashlytics.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1988,7 +1974,6 @@
 				6E10A4ED1D1066E9008CBD0C /* Frameworks */,
 				6E10A4EE1D1066E9008CBD0C /* Headers */,
 				6E10A4EF1D1066E9008CBD0C /* Resources */,
-				6E3B98A61D4A6840009B4926 /* Copy Configurations */,
 			);
 			buildRules = (
 			);

--- a/OpenStack Summit/OpenStack Summit/AppDelegate.swift
+++ b/OpenStack Summit/OpenStack Summit/AppDelegate.swift
@@ -15,6 +15,8 @@ import Parse
 import CoreSpotlight
 import RealmSwift
 import XCDYouTubeKit
+import Fabric
+import Crashlytics
 
 @UIApplicationMain
 final class AppDelegate: UIResponder, UIApplicationDelegate, SummitActivityHandling {
@@ -41,6 +43,8 @@ final class AppDelegate: UIResponder, UIApplicationDelegate, SummitActivityHandl
         // verify Fabric integration
         assert(NSBundle.mainBundle().infoDictionary!["Fabric"] != nil, "Fabric missing from Info.plist \n \(NSBundle.mainBundle().infoDictionary!)")
         
+        Fabric.with([Crashlytics.self])
+        
         // nuke Realm if errored
         do { let _ = try Realm() }
         catch {
@@ -59,6 +63,9 @@ final class AppDelegate: UIResponder, UIApplicationDelegate, SummitActivityHandl
             // clear data poller
             var pollerStorage = UserDefaultsDataUpdatePollerStorage()
             pollerStorage.clear()
+            
+            // log nuking realm
+            Crashlytics.sharedInstance().recordError(error as NSError)
         }
         
         // set configuration

--- a/OpenStack Summit/OpenStack Summit/AppDelegate.swift
+++ b/OpenStack Summit/OpenStack Summit/AppDelegate.swift
@@ -38,6 +38,9 @@ final class AppDelegate: UIResponder, UIApplicationDelegate, SummitActivityHandl
         // update app build preference
         Preference.appBuild = AppBuild
         
+        // verify Fabric integration
+        assert(NSBundle.mainBundle().infoDictionary!["Fabric"] != nil, "Fabric missing from Info.plist \n \(NSBundle.mainBundle().infoDictionary!)")
+        
         // nuke Realm if errored
         do { let _ = try Realm() }
         catch {

--- a/OpenStack Summit/OpenStack Summit/MenuViewController.swift
+++ b/OpenStack Summit/OpenStack Summit/MenuViewController.swift
@@ -10,6 +10,7 @@ import UIKit
 import SwiftSpinner
 import AeroGearOAuth2
 import CoreSummit
+import Crashlytics
 
 final class MenuViewController: UIViewController, UITextFieldDelegate, ShowActivityIndicatorProtocol, SWRevealViewControllerDelegate, MessageEnabledViewController {
     
@@ -369,8 +370,10 @@ final class MenuViewController: UIViewController, UITextFieldDelegate, ShowActiv
                         controller.toggleMenuSelection(controller.myProfileButton)
                     }
                     
-                    PushNotificationsManager.subscribeToPushChannelsUsingContext({ (succeeded, error) in
-                    })
+                    // log user email
+                    Crashlytics.sharedInstance().setUserEmail(Store.shared.authenticatedMember!.email)
+                    
+                    PushNotificationsManager.subscribeToPushChannelsUsingContext({ (succeeded, error) in })
                 }
             }
         }
@@ -379,6 +382,8 @@ final class MenuViewController: UIViewController, UITextFieldDelegate, ShowActiv
     private func logout() {
         
         Store.shared.logout()
+        
+        Crashlytics.sharedInstance().setUserEmail(nil)
         
         showUserProfile()
         navigateToHome()

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Supports iOS, watchOS and tvOS.
 	CoreSummit/Staging.swift.xctemplate -> CoreSummit/Staging.swift
 	CoreSummit/Production.swift.xctemplate -> CoreSummit/Production.swift
 	OpenStack Summit/AppConsumerKey.swift.xctemplate -> OpenStack Summit/AppConsumerKey.swift
+	OpenStack Summit/FabricInfoPlist.swift.xctemplate -> OpenStack Summit/FabricInfoPlist.swift
 	```
 
 3. Generate .entitlements out of sample entitlements files

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Supports iOS, watchOS and tvOS.
 	```
 	carthage bootstrap
 	```
-2. Download Google Maps SDK [1.13.2](https://www.gstatic.com/cpdc/aa3052925ceeea2d-GoogleMaps-1.13.2.tar.gz) and copy to `Vendor` folder.
+2. Download [Google Maps SDK](https://www.gstatic.com/cpdc/aa3052925ceeea2d-GoogleMaps-1.13.2.tar.gz), [Fabric](https://kit-downloads.fabric.io/cocoapods/fabric/1.6.9/fabric.zip), [Crashlytics](https://kit-downloads.fabric.io/cocoapods/crashlytics/3.8.1/crashlytics.zip) and copy to `Vendor` folder.
 
 3. Generate .swift out of sample configuration files
 


### PR DESCRIPTION
Currently, a failed data update will block the data updates process.
We need to discard troubled data update and log (through Crashalytics) the necessary info to track down the cause (data issue, parsing issue) and provide a future fix.
Probably need to set consumer keys per app.