### PR TITLE
[12015] Log current user's email in Crashlytics

### DIFF
--- a/OpenStack Summit/OpenStack Summit/MenuViewController.swift
+++ b/OpenStack Summit/OpenStack Summit/MenuViewController.swift
@@ -370,6 +370,9 @@ final class MenuViewController: UIViewController, UITextFieldDelegate, ShowActiv
                         controller.toggleMenuSelection(controller.myProfileButton)
                     }
                     
+                    // log user email
+                    Crashlytics.sharedInstance().setUserEmail(Store.shared.authenticatedMember!.email)
+                    
                     PushNotificationsManager.subscribeToPushChannelsUsingContext({ (succeeded, error) in })
                 }
             }

--- a/OpenStack Summit/OpenStack Summit/MenuViewController.swift
+++ b/OpenStack Summit/OpenStack Summit/MenuViewController.swift
@@ -371,7 +371,7 @@ final class MenuViewController: UIViewController, UITextFieldDelegate, ShowActiv
                     }
                     
                     // log user email
-                    Crashlytics.sharedInstance().setUserEmail(Store.shared.authenticatedMember!.email)
+                    Crashlytics.sharedInstance().setUserEmail(Store.shared.authenticatedMember?.email)
                     
                     PushNotificationsManager.subscribeToPushChannelsUsingContext({ (succeeded, error) in })
                 }


### PR DESCRIPTION
- Forgot that `Store.authenticatedMember` can be `nil` when
authenticating as non-confirmed attendee
- Also fixes 12008 (App Crashes after login and subsequently on launch)