### PR TITLE
Fixed potential crash for Invalid HTML in EventDetailVC

### DIFF
--- a/OpenStack Summit/OpenStack Summit/EventDetailViewController.swift
+++ b/OpenStack Summit/OpenStack Summit/EventDetailViewController.swift
@@ -444,9 +444,16 @@ final class EventDetailViewController: UITableViewController, ShowActivityIndica
                 let cell = tableView.dequeueReusableCellWithIdentifier(R.reuseIdentifier.eventDetailDescriptionTableViewCell, forIndexPath: indexPath)!
                 
                 let eventDescriptionHTML = String(format:"<style>p:last-of-type { display:compact }</style><span style=\"font-family: Arial; font-size: 13\">%@</span>", eventDetail.eventDescription)
-                let attrStr = try! NSAttributedString(data: eventDescriptionHTML.dataUsingEncoding(NSUnicodeStringEncoding, allowLossyConversion: false)!, options: [NSDocumentTypeDocumentAttribute: NSHTMLTextDocumentType], documentAttributes: nil)
+                if let data = eventDescriptionHTML.dataUsingEncoding(NSUnicodeStringEncoding, allowLossyConversion: false),
+                    let attrStr = try? NSAttributedString(data: data, options: [NSDocumentTypeDocumentAttribute: NSHTMLTextDocumentType], documentAttributes: nil) {
+                    
+                    cell.descriptionTextView.attributedText = attrStr
+                    
+                } else {
+                    
+                    cell.descriptionTextView.text = ""
+                }
                 
-                cell.descriptionTextView.attributedText = attrStr
                 cell.descriptionTextView.textContainerInset = UIEdgeInsetsZero
                 
                 cell.descriptionTextView.delegate = self

--- a/OpenStack Summit/OpenStack Summit/MemberProfileDetailViewController.swift
+++ b/OpenStack Summit/OpenStack Summit/MemberProfileDetailViewController.swift
@@ -43,13 +43,19 @@ final class MemberProfileDetailViewController: UIViewController, IndicatorInfoPr
         
         didSet {
             
-            let attrStr = try! NSMutableAttributedString(data: biographyHTML.dataUsingEncoding(NSUnicodeStringEncoding, allowLossyConversion: false)!, options: [NSDocumentTypeDocumentAttribute: NSHTMLTextDocumentType], documentAttributes: nil)
-            
-            let range = NSMakeRange(0, attrStr.length)
-            
-            attrStr.addAttribute(NSFontAttributeName, value: UIFont.systemFontOfSize(14), range: range)
-            
-            bioTextView.attributedText = attrStr
+            if let data = biographyHTML.dataUsingEncoding(NSUnicodeStringEncoding, allowLossyConversion: false),
+                let attrStr = try? NSMutableAttributedString(data: data, options: [NSDocumentTypeDocumentAttribute: NSHTMLTextDocumentType], documentAttributes: nil) {
+                
+                let range = NSMakeRange(0, attrStr.length)
+                
+                attrStr.addAttribute(NSFontAttributeName, value: UIFont.systemFontOfSize(14), range: range)
+                
+                bioTextView.attributedText = attrStr
+                
+            } else {
+                
+                bioTextView.text = ""
+            }
         }
     }
     


### PR DESCRIPTION
Would crash if attributed string could not be created from HTML.