### PR TITLE
[12022] [iOS] Log user email only on beta release

### DIFF
--- a/OpenStack Summit/OpenStack Summit/MenuViewController.swift
+++ b/OpenStack Summit/OpenStack Summit/MenuViewController.swift
@@ -371,7 +371,10 @@ final class MenuViewController: UIViewController, UITextFieldDelegate, ShowActiv
                     }
                     
                     // log user email
-                    Crashlytics.sharedInstance().setUserEmail(Store.shared.authenticatedMember?.email)
+                    if AppEnvironment == .Staging {
+                        
+                        Crashlytics.sharedInstance().setUserEmail(Store.shared.authenticatedMember?.email)
+                    }
                     
                     PushNotificationsManager.subscribeToPushChannelsUsingContext({ (succeeded, error) in })
                 }
@@ -383,7 +386,11 @@ final class MenuViewController: UIViewController, UITextFieldDelegate, ShowActiv
         
         Store.shared.logout()
         
-        Crashlytics.sharedInstance().setUserEmail(nil)
+        // log user email
+        if AppEnvironment == .Staging {
+            
+            Crashlytics.sharedInstance().setUserEmail(nil)
+        }
         
         showUserProfile()
         navigateToHome()


### PR DESCRIPTION
Attendee emails are sensitive.
Log only on beta release.