### PR TITLE
[iOS] [11225] Show events still going on.

### DIFF
--- a/OpenStack Summit/CoreSummit/EventManagedObject.swift
+++ b/OpenStack Summit/CoreSummit/EventManagedObject.swift
@@ -117,7 +117,7 @@ public extension EventManagedObject {
                        venues: [Identifier]?,
                        context: NSManagedObjectContext) throws -> [EventManagedObject] {
         
-        let eventsPredicate = NSPredicate(format: "start >= %@ AND end <= %@", startDate, endDate)
+        let eventsPredicate = NSPredicate(format: "end >= %@ AND end <= %@", startDate, endDate)
         
         var predicates = [eventsPredicate]
         

--- a/OpenStack Summit/CoreSummit/EventManagedObject.swift
+++ b/OpenStack Summit/CoreSummit/EventManagedObject.swift
@@ -196,7 +196,7 @@ public extension EventManagedObject {
         guard let speaker = try SpeakerManagedObject.find(speaker, context: context)
             else { return [] }
         
-        let predicate = NSPredicate(format: "(ANY presentation.speakers == %@ OR presentation.moderator == %@) AND (start >= %@ AND end <= %@)", speaker, speaker, startDate, endDate)
+        let predicate = NSPredicate(format: "(ANY presentation.speakers == %@ OR presentation.moderator == %@) AND (end >= %@ AND end <= %@)", speaker, speaker, startDate, endDate)
         
         return try context.managedObjects(EventManagedObject.self, predicate: predicate, sortDescriptors: sortDescriptors)
     }

--- a/OpenStack Summit/CoreSummit/RealmSummitEvent.swift
+++ b/OpenStack Summit/CoreSummit/RealmSummitEvent.swift
@@ -47,7 +47,7 @@ public extension RealmSummitEvent {
     
     static func filter(startDate: NSDate, endDate: NSDate, summitTypes: [Int]?, tracks: [Int]?, trackGroups: [Int]?, tags: [String]?, levels: [String]?, venues: [Int]?, realm: Realm = Store.shared.realm) -> [RealmSummitEvent] {
         
-        var events = realm.objects(RealmSummitEvent).filter("start >= %@ and end <= %@", startDate, endDate).sorted(RealmSummitEvent.sortProperties)
+        var events = realm.objects(RealmSummitEvent).filter("end >= %@ and end <= %@", startDate, endDate).sorted(RealmSummitEvent.sortProperties)
         
         if (summitTypes != nil && summitTypes!.count > 0) {
             for summitTypeId in summitTypes! {

--- a/OpenStack Summit/CoreSummit/RealmSummitEvent.swift
+++ b/OpenStack Summit/CoreSummit/RealmSummitEvent.swift
@@ -91,7 +91,7 @@ public extension RealmSummitEvent {
     }
     
     static func speakerPresentations(speaker: Identifier, startDate: NSDate, endDate: NSDate, realm: Realm = Store.shared.realm) -> [RealmSummitEvent] {
-        let events = realm.objects(RealmSummitEvent).filter("ANY presentation.speakers.id = %@ || presentation.moderator.id = %@ && start >= %@ and end <= %@", speaker, speaker, startDate, endDate).sorted(self.sortProperties)
+        let events = realm.objects(RealmSummitEvent).filter("ANY presentation.speakers.id = %@ || presentation.moderator.id = %@ && end >= %@ and end <= %@", speaker, speaker, startDate, endDate).sorted(self.sortProperties)
         return events.map { $0 }
     }
 }


### PR DESCRIPTION
Applying hide past events filter would hide events currently going on.
This PR proposes using only events end date for filtering.