### PR TITLE
[11685] Set a "default start date" for the Summit

### DIFF
--- a/OpenStack Summit/CoreSummit/Model.xcdatamodeld/Model.xcdatamodel/contents
+++ b/OpenStack Summit/CoreSummit/Model.xcdatamodeld/Model.xcdatamodel/contents
@@ -125,6 +125,7 @@
         <attribute name="end" attributeType="Date" syncable="YES"/>
         <attribute name="id" attributeType="Integer 64" defaultValueString="0" syncable="YES"/>
         <attribute name="initialDataLoad" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="defaultStart" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="name" attributeType="String" syncable="YES"/>
         <attribute name="start" attributeType="Date" syncable="YES"/>
         <attribute name="startShowingVenues" optional="YES" attributeType="Date" syncable="YES"/>

--- a/OpenStack Summit/CoreSummit/Summit.swift
+++ b/OpenStack Summit/CoreSummit/Summit.swift
@@ -20,6 +20,9 @@ public struct Summit: Named, Equatable {
     
     public var end: Date
     
+    /// Default start date for the Summit.
+    public var defaultStart: Date?
+    
     public var active: Bool
     
     public var sponsors: Set<Company>

--- a/OpenStack Summit/CoreSummit/SummitJSON.swift
+++ b/OpenStack Summit/CoreSummit/SummitJSON.swift
@@ -12,7 +12,7 @@ public extension Summit {
     
     enum JSONKey: String {
         
-        case id, name, start_date, end_date, time_zone, logo, active, start_showing_venues_date, sponsors, summit_types, ticket_types, event_types, tracks, track_groups, locations, speakers, schedule, timestamp, page_url
+        case id, name, start_date, end_date, schedule_start_date, time_zone, logo, active, start_showing_venues_date, sponsors, summit_types, ticket_types, event_types, tracks, track_groups, locations, speakers, schedule, timestamp, page_url
     }
 }
 
@@ -82,6 +82,15 @@ extension Summit: JSONDecodable {
         } else {
             
             self.startShowingVenues = nil
+        }
+        
+        if let scheduleStartDate = JSONObject[JSONKey.schedule_start_date.rawValue]?.rawValue as? Int {
+            
+            self.defaultStart = Date(timeIntervalSince1970: TimeInterval(scheduleStartDate))
+            
+        } else {
+            
+            self.defaultStart = nil
         }
     }
 }

--- a/OpenStack Summit/CoreSummit/SummitManagedObject.swift
+++ b/OpenStack Summit/CoreSummit/SummitManagedObject.swift
@@ -23,6 +23,8 @@ public final class SummitManagedObject: Entity {
     
     @NSManaged public var end: NSDate
     
+    @NSManaged public var defaultStart: NSDate?
+    
     @NSManaged public var webpageURL: String
     
     @NSManaged public var active: Bool
@@ -67,6 +69,15 @@ extension Summit: CoreDataDecodable {
             self.startShowingVenues = nil
         }
         
+        if let defaultStart = managedObject.defaultStart {
+            
+            self.defaultStart = Date(foundation: defaultStart)
+            
+        } else {
+            
+            self.defaultStart = nil
+        }
+        
         self.sponsors = Company.from(managedObjects: managedObject.sponsors)
         self.speakers = Speaker.from(managedObjects: managedObject.speakers)
         self.ticketTypes = TicketType.from(managedObjects: managedObject.ticketTypes)
@@ -88,6 +99,7 @@ extension Summit: CoreDataEncodable {
         managedObject.timeZone = timeZone
         managedObject.start = start.toFoundation()
         managedObject.end = end.toFoundation()
+        managedObject.defaultStart = defaultStart?.toFoundation()
         managedObject.webpageURL = webpageURL
         managedObject.active = active
         managedObject.startShowingVenues = startShowingVenues?.toFoundation()

--- a/OpenStack Summit/OpenStack Summit/ScheduleViewController.swift
+++ b/OpenStack Summit/OpenStack Summit/ScheduleViewController.swift
@@ -215,7 +215,11 @@ class ScheduleViewController: UIViewController, MessageEnabledViewController, Sh
         
         self.subscribeToPushChannelsUsingContextIfNotDoneAlready()
         
-        self.summitTimeZoneOffset = NSTimeZone(name: summit.timeZone)!.secondsFromGMT
+        let timeZone = NSTimeZone(name: summit.timeZone)!
+        
+        NSDate.mt_setTimeZone(timeZone)
+        
+        self.summitTimeZoneOffset = timeZone.secondsFromGMT
         
         self.startDate = summit.start.toFoundation().mt_dateSecondsAfter(self.summitTimeZoneOffset).mt_startOfCurrentDay()
         self.endDate = summit.end.toFoundation().mt_dateSecondsAfter(self.summitTimeZoneOffset).mt_dateDaysAfter(1)
@@ -241,6 +245,7 @@ class ScheduleViewController: UIViewController, MessageEnabledViewController, Sh
         } else if self.didSelectDate == false || self.availableDates.contains(self.selectedDate) == false {
             
             self.selectedDate = self.availableDates.firstMatching({ $0.mt_isWithinSameDay(today) }) ?? self.availableDates.first
+            
         } else {
             
             self.selectedDate = oldSelectedDate

--- a/OpenStack Summit/OpenStack Summit/ScheduleViewController.swift
+++ b/OpenStack Summit/OpenStack Summit/ScheduleViewController.swift
@@ -237,7 +237,15 @@ class ScheduleViewController: UIViewController, MessageEnabledViewController, Sh
             }
         }
         else {
-            if self.availableDates.count > 0 {
+            
+            let summitActive = today.mt_isBetweenDate(self.startDate, andDate: self.endDate)
+            
+            // default start day when summit is inactive
+            if let defaultStart = summit.defaultStart where summitActive == false {
+                
+                self.selectedDate = defaultStart.toFoundation()
+            
+            } else if self.availableDates.count > 0 {
                 var selected = self.availableDates.first
                 for availableDate in self.availableDates {
                     if availableDate.mt_isWithinSameDay(today) {
@@ -248,6 +256,7 @@ class ScheduleViewController: UIViewController, MessageEnabledViewController, Sh
                 self.selectedDate = selected
             }
             else {
+                
                 self.selectedDate = self.startDate
             }
         }


### PR DESCRIPTION
Set a "default start date" for the Summit. Typically we have Sunday/Monday as less attended content. We'd like to default to a particular day (this year Tuesday, but it changes every Summit).