### PR TITLE
[12332] Add `Now` button to Schedule

### DIFF
--- a/OpenStack Summit/OpenStack Summit/GeneralScheduleViewController.swift
+++ b/OpenStack Summit/OpenStack Summit/GeneralScheduleViewController.swift
@@ -10,6 +10,7 @@
 import UIKit
 import XLPagerTabStrip
 import SwiftSpinner
+import SwiftFoundation
 import CoreSummit
 
 final class GeneralScheduleViewController: ScheduleViewController, IndicatorInfoProvider {
@@ -93,7 +94,9 @@ final class GeneralScheduleViewController: ScheduleViewController, IndicatorInfo
         let levels = scheduleFilter.selections[FilterSectionType.Level]?.rawValue as? [String]
         let venues = scheduleFilter.selections[FilterSectionType.Venue]?.rawValue as? [Int]
         
-        let events = try! EventManagedObject.filter(startDate, endDate: endDate, tracks: tracks, trackGroups: trackGroups, tags: tags, levels: levels, venues: venues, summit: summit, context: Store.shared.managedObjectContext)
+        let date = DateFilter.interval(start: Date(foundation: startDate), end: Date(foundation: endDate))
+        
+        let events = try! EventManagedObject.filter(date, tracks: tracks, trackGroups: trackGroups, tags: tags, levels: levels, venues: venues, summit: summit, context: Store.shared.managedObjectContext)
         
         var activeDates: [NSDate] = []
         for event in events {
@@ -107,7 +110,7 @@ final class GeneralScheduleViewController: ScheduleViewController, IndicatorInfo
         return activeDates
     }
     
-    override func scheduledEvents(from startDate: NSDate, to endDate: NSDate) -> [ScheduleItem] {
+    override func scheduledEvents(filter: DateFilter) -> [ScheduleItem] {
         
         let scheduleFilter = FilterManager.shared.filter.value
         let summit = SummitManager.shared.summit.value
@@ -118,7 +121,7 @@ final class GeneralScheduleViewController: ScheduleViewController, IndicatorInfo
         let levels = scheduleFilter.selections[FilterSectionType.Level]?.rawValue as? [String]
         let venues = scheduleFilter.selections[FilterSectionType.Venue]?.rawValue as? [Int]
         
-        let events = try! EventManagedObject.filter(startDate, endDate: endDate, tracks: tracks, trackGroups: trackGroups, tags: tags, levels: levels, venues: venues, summit: summit, context: Store.shared.managedObjectContext)
+        let events = try! EventManagedObject.filter(filter, tracks: tracks, trackGroups: trackGroups, tags: tags, levels: levels, venues: venues, summit: summit, context: Store.shared.managedObjectContext)
         
         return ScheduleItem.from(managedObjects: events)
     }

--- a/OpenStack Summit/OpenStack Summit/LevelScheduleViewController.swift
+++ b/OpenStack Summit/OpenStack Summit/LevelScheduleViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import SwiftFoundation
 import CoreSummit
 
 final class LevelScheduleViewController: ScheduleViewController {
@@ -38,7 +39,9 @@ final class LevelScheduleViewController: ScheduleViewController {
         let tags = scheduleFilter.selections[FilterSectionType.Tag]?.rawValue as? [String]
         let venues = scheduleFilter.selections[FilterSectionType.Venue]?.rawValue as? [Int]
         
-        let events = try! EventManagedObject.filter(startDate, endDate: endDate, tracks: tracks, trackGroups: trackGroups, tags: tags, levels: levels, venues: venues, summit: summit, context: Store.shared.managedObjectContext)
+        let date = DateFilter.interval(start: Date(foundation: startDate), end: Date(foundation: endDate))
+        
+        let events = try! EventManagedObject.filter(date, tracks: tracks, trackGroups: trackGroups, tags: tags, levels: levels, venues: venues, summit: summit, context: Store.shared.managedObjectContext)
         
         var activeDates: [NSDate] = []
         for event in events {
@@ -52,7 +55,7 @@ final class LevelScheduleViewController: ScheduleViewController {
         return activeDates
     }
     
-    override func scheduledEvents(from startDate: NSDate, to endDate: NSDate) -> [ScheduleItem] {
+    override func scheduledEvents(filter: DateFilter) -> [ScheduleItem] {
         
         let scheduleFilter = FilterManager.shared.filter.value
         let summit = SummitManager.shared.summit.value
@@ -63,7 +66,7 @@ final class LevelScheduleViewController: ScheduleViewController {
         let tags = scheduleFilter.selections[FilterSectionType.Tag]?.rawValue as? [String]
         let venues = scheduleFilter.selections[FilterSectionType.Venue]?.rawValue as? [Int]
         
-        let events = try! EventManagedObject.filter(startDate, endDate: endDate, tracks: tracks, trackGroups: trackGroups, tags: tags, levels: levels, venues: venues, summit: summit, context: Store.shared.managedObjectContext)
+        let events = try! EventManagedObject.filter(filter, tracks: tracks, trackGroups: trackGroups, tags: tags, levels: levels, venues: venues, summit: summit, context: Store.shared.managedObjectContext)
         
         return ScheduleItem.from(managedObjects: events)
     }

--- a/OpenStack Summit/OpenStack Summit/PersonalScheduleViewController.swift
+++ b/OpenStack Summit/OpenStack Summit/PersonalScheduleViewController.swift
@@ -37,7 +37,7 @@ final class PersonalScheduleViewController: ScheduleViewController, IndicatorInf
         return activeDates
     }
     
-    override func scheduledEvents(from startDate: NSDate, to endDate: NSDate) -> [ScheduleItem] {
+    override func scheduledEvents(filter: DateFilter) -> [ScheduleItem] {
         
         guard let attendeeRole = Store.shared.authenticatedMember?.attendeeRole
             else { return [] }

--- a/OpenStack Summit/OpenStack Summit/ScheduleView.swift
+++ b/OpenStack Summit/OpenStack Summit/ScheduleView.swift
@@ -16,6 +16,18 @@ final class ScheduleView: UIView {
     @IBOutlet weak var tableView: UITableView!
     @IBOutlet weak var noEventsLabel: UILabel!
     @IBOutlet weak var nowButton: UIButton!
+    @IBOutlet private weak var nowWidthConstraint: NSLayoutConstraint!
+    
+    var nowButtonEnabled: Bool = true {
+        
+        didSet {
+            
+            self.nowWidthConstraint.constant = nowButtonEnabled ? 60 : 0
+            self.nowButton.hidden = nowButtonEnabled == false
+            
+            self.needsUpdateConstraints()
+        }
+    }
     
     var activeDates: [NSDate] = []
     

--- a/OpenStack Summit/OpenStack Summit/ScheduleView.swift
+++ b/OpenStack Summit/OpenStack Summit/ScheduleView.swift
@@ -15,6 +15,7 @@ final class ScheduleView: UIView {
     @IBOutlet weak var dayPicker: AFHorizontalDayPicker!
     @IBOutlet weak var tableView: UITableView!
     @IBOutlet weak var noEventsLabel: UILabel!
+    @IBOutlet weak var nowButton: UIButton!
     
     var activeDates: [NSDate] = []
     

--- a/OpenStack Summit/OpenStack Summit/ScheduleView.xib
+++ b/OpenStack Summit/OpenStack Summit/ScheduleView.xib
@@ -16,6 +16,7 @@
                 <outlet property="dayPicker" destination="BrO-92-FB5" id="QeQ-r1-tpo"/>
                 <outlet property="noEventsLabel" destination="7UD-xN-OK6" id="zSz-7o-ugC"/>
                 <outlet property="nowButton" destination="wis-wA-eYi" id="N13-1o-8uE"/>
+                <outlet property="nowWidthConstraint" destination="xbY-Tq-wbw" id="80d-3N-3B4"/>
                 <outlet property="tableView" destination="GXx-g3-Qpp" id="piT-40-yBW"/>
                 <outlet property="view" destination="iN0-l3-epB" id="jBk-DV-KBV"/>
             </connections>
@@ -46,11 +47,12 @@
                     <rect key="frame" x="0.0" y="0.0" width="60" height="52"/>
                     <subviews>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wis-wA-eYi">
-                            <rect key="frame" x="11.5" y="11" width="37" height="30"/>
+                            <rect key="frame" x="12" y="11" width="37" height="30"/>
+                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                             <state key="normal" title="NOW"/>
                         </button>
                     </subviews>
-                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    <color key="backgroundColor" red="0.89803921568627454" green="0.89803921568627454" blue="0.89803921568627454" alpha="1" colorSpace="calibratedRGB"/>
                     <constraints>
                         <constraint firstItem="wis-wA-eYi" firstAttribute="centerY" secondItem="Q0e-J9-8kd" secondAttribute="centerY" id="Psh-oN-2pT"/>
                         <constraint firstItem="wis-wA-eYi" firstAttribute="centerX" secondItem="Q0e-J9-8kd" secondAttribute="centerX" id="aKD-hV-vo4"/>

--- a/OpenStack Summit/OpenStack Summit/ScheduleView.xib
+++ b/OpenStack Summit/OpenStack Summit/ScheduleView.xib
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11542" systemVersion="15G1108" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11542" systemVersion="16C67" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
     <device id="retina4_0" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
@@ -15,6 +15,7 @@
             <connections>
                 <outlet property="dayPicker" destination="BrO-92-FB5" id="QeQ-r1-tpo"/>
                 <outlet property="noEventsLabel" destination="7UD-xN-OK6" id="zSz-7o-ugC"/>
+                <outlet property="nowButton" destination="wis-wA-eYi" id="N13-1o-8uE"/>
                 <outlet property="tableView" destination="GXx-g3-Qpp" id="piT-40-yBW"/>
                 <outlet property="view" destination="iN0-l3-epB" id="jBk-DV-KBV"/>
             </connections>
@@ -25,7 +26,7 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BrO-92-FB5" customClass="AFHorizontalDayPicker">
-                    <rect key="frame" x="0.0" y="0.0" width="320" height="52"/>
+                    <rect key="frame" x="60" y="0.0" width="260" height="52"/>
                     <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="52" id="1nl-Dj-Xfi"/>
@@ -36,22 +37,48 @@
                     <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                 </tableView>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="No events for current day" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7UD-xN-OK6">
-                    <rect key="frame" x="62.5" y="273.5" width="195" height="21"/>
+                    <rect key="frame" x="63" y="274" width="195" height="21"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <nil key="highlightedColor"/>
                 </label>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Q0e-J9-8kd">
+                    <rect key="frame" x="0.0" y="0.0" width="60" height="52"/>
+                    <subviews>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wis-wA-eYi">
+                            <rect key="frame" x="11.5" y="11" width="37" height="30"/>
+                            <state key="normal" title="NOW"/>
+                        </button>
+                    </subviews>
+                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    <constraints>
+                        <constraint firstItem="wis-wA-eYi" firstAttribute="centerY" secondItem="Q0e-J9-8kd" secondAttribute="centerY" id="Psh-oN-2pT"/>
+                        <constraint firstItem="wis-wA-eYi" firstAttribute="centerX" secondItem="Q0e-J9-8kd" secondAttribute="centerX" id="aKD-hV-vo4"/>
+                        <constraint firstAttribute="width" constant="60" id="xbY-Tq-wbw"/>
+                    </constraints>
+                </view>
             </subviews>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="GXx-g3-Qpp" firstAttribute="top" secondItem="BrO-92-FB5" secondAttribute="bottom" id="0ud-k0-dfZ"/>
                 <constraint firstItem="GXx-g3-Qpp" firstAttribute="bottom" secondItem="iN0-l3-epB" secondAttribute="bottom" id="5dW-zO-rIF"/>
+                <constraint firstItem="Q0e-J9-8kd" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="6qi-ef-EsC"/>
                 <constraint firstItem="GXx-g3-Qpp" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="8xh-VM-201"/>
+                <constraint firstItem="BrO-92-FB5" firstAttribute="leading" secondItem="Q0e-J9-8kd" secondAttribute="trailing" id="D1C-Kz-Lzn"/>
                 <constraint firstItem="GXx-g3-Qpp" firstAttribute="trailing" secondItem="iN0-l3-epB" secondAttribute="trailing" id="Lnr-dn-VRU"/>
+                <constraint firstItem="GXx-g3-Qpp" firstAttribute="top" secondItem="Q0e-J9-8kd" secondAttribute="bottom" id="OY5-Io-kY5"/>
+                <constraint firstItem="BrO-92-FB5" firstAttribute="leading" secondItem="Q0e-J9-8kd" secondAttribute="trailing" id="OnT-C4-F9R"/>
+                <constraint firstItem="Q0e-J9-8kd" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="VIB-Qb-xBv"/>
+                <constraint firstItem="Q0e-J9-8kd" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="XA3-mI-tX6"/>
+                <constraint firstItem="GXx-g3-Qpp" firstAttribute="top" secondItem="Q0e-J9-8kd" secondAttribute="bottom" id="gCa-td-BQf"/>
+                <constraint firstItem="BrO-92-FB5" firstAttribute="leading" secondItem="Q0e-J9-8kd" secondAttribute="trailing" id="gXE-IN-9Vs"/>
                 <constraint firstItem="BrO-92-FB5" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="kcz-XP-jhS"/>
+                <constraint firstItem="GXx-g3-Qpp" firstAttribute="top" secondItem="Q0e-J9-8kd" secondAttribute="bottom" id="mkW-gG-xKm"/>
+                <constraint firstItem="Q0e-J9-8kd" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="oDo-px-ivP"/>
+                <constraint firstItem="Q0e-J9-8kd" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="oax-sw-ShK"/>
+                <constraint firstItem="Q0e-J9-8kd" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="oiz-WW-0ym"/>
                 <constraint firstItem="7UD-xN-OK6" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="centerYWithinMargins" id="tqu-8p-qMd"/>
                 <constraint firstItem="7UD-xN-OK6" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerXWithinMargins" id="uFw-47-oSA"/>
-                <constraint firstItem="BrO-92-FB5" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="umo-ga-8OA"/>
                 <constraint firstItem="BrO-92-FB5" firstAttribute="trailing" secondItem="iN0-l3-epB" secondAttribute="trailing" id="zzU-YO-hNf"/>
             </constraints>
             <point key="canvasLocation" x="506" y="296"/>

--- a/OpenStack Summit/OpenStack Summit/ScheduleViewController.swift
+++ b/OpenStack Summit/OpenStack Summit/ScheduleViewController.swift
@@ -86,6 +86,7 @@ class ScheduleViewController: UIViewController, MessageEnabledViewController, Sh
         setBlankBackBarButtonItem()
         
         scheduleView.dayPicker.delegate = self
+        scheduleView.nowButton.addTarget(self, action: #selector(nowTapped), forControlEvents: .TouchUpInside)
         
         scheduleView.tableView.registerNib(R.nib.scheduleTableViewCell)
         scheduleView.tableView.delegate = self
@@ -152,6 +153,11 @@ class ScheduleViewController: UIViewController, MessageEnabledViewController, Sh
             
             Store.shared.addEventToSchedule(event.summit, event: event.id, completion: completion)
         }
+    }
+    
+    @IBAction func nowTapped(sender: UIButton) {
+        
+        
     }
     
     // MARK: - Methods

--- a/OpenStack Summit/OpenStack Summit/ScheduleViewController.swift
+++ b/OpenStack Summit/OpenStack Summit/ScheduleViewController.swift
@@ -249,6 +249,8 @@ class ScheduleViewController: UIViewController, MessageEnabledViewController, Sh
         
         let summitActive = today.mt_isBetweenDate(self.startDate, andDate: self.endDate)
         
+        self.scheduleView.nowButtonEnabled = summitActive
+        
         // default start day when summit is inactive
         
         let oldSelectedDate = self.selectedDate

--- a/OpenStack Summit/OpenStack Summit/SpeakerPresentationsViewController.swift
+++ b/OpenStack Summit/OpenStack Summit/SpeakerPresentationsViewController.swift
@@ -46,7 +46,7 @@ final class SpeakerPresentationsViewController: ScheduleViewController, Indicato
         return activeDates
     }
     
-    override func scheduledEvents(from startDate: NSDate, to endDate: NSDate) -> [ScheduleItem] {
+    override func scheduledEvents(filter: DateFilter) -> [ScheduleItem] {
         
         let summit = SummitManager.shared.summit.value
         

--- a/OpenStack Summit/OpenStack Summit/TrackScheduleViewController.swift
+++ b/OpenStack Summit/OpenStack Summit/TrackScheduleViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import SwiftFoundation
 import CoreSummit
 
 final class TrackScheduleViewController: ScheduleViewController {
@@ -49,7 +50,9 @@ final class TrackScheduleViewController: ScheduleViewController {
         let levels = scheduleFilter.selections[FilterSectionType.Level]?.rawValue as? [String]
         let venues = scheduleFilter.selections[FilterSectionType.Venue]?.rawValue as? [Int]
         
-        let events = try! EventManagedObject.filter(startDate, endDate: endDate, tracks: tracks, trackGroups: trackGroups, tags: tags, levels: levels, venues: venues, summit: summit, context: Store.shared.managedObjectContext)
+        let date = DateFilter.interval(start: Date(foundation: startDate), end: Date(foundation: endDate))
+        
+        let events = try! EventManagedObject.filter(date, tracks: tracks, trackGroups: trackGroups, tags: tags, levels: levels, venues: venues, summit: summit, context: Store.shared.managedObjectContext)
         
         var activeDates: [NSDate] = []
         for event in events {
@@ -63,7 +66,7 @@ final class TrackScheduleViewController: ScheduleViewController {
         return activeDates
     }
     
-    override func scheduledEvents(from startDate: NSDate, to endDate: NSDate) -> [ScheduleItem] {
+    override func scheduledEvents(filter: DateFilter) -> [ScheduleItem] {
         
         let scheduleFilter = FilterManager.shared.filter.value
         let summit = SummitManager.shared.summit.value
@@ -74,7 +77,7 @@ final class TrackScheduleViewController: ScheduleViewController {
         let levels = scheduleFilter.selections[FilterSectionType.Level]?.rawValue as? [String]
         let venues = scheduleFilter.selections[FilterSectionType.Venue]?.rawValue as? [Int]
         
-        let events = try! EventManagedObject.filter(startDate, endDate: endDate, tracks: tracks, trackGroups: trackGroups, tags: tags, levels: levels, venues: venues, summit: summit, context: Store.shared.managedObjectContext)
+        let events = try! EventManagedObject.filter(filter, tracks: tracks, trackGroups: trackGroups, tags: tags, levels: levels, venues: venues, summit: summit, context: Store.shared.managedObjectContext)
         
         return ScheduleItem.from(managedObjects: events)
     }


### PR DESCRIPTION
- NOW button only shows during summit.
- NOW should respect all filters and show the events occurring "now" (between Start/End date of any event). This includes ALL Event Types
- Between Summit Start/End, if not logged in, default to the NOW view
- Between Summit Start/End, if logged in, default to My Schedule