### PR TITLE
[12732] RSVP UX Flow

### DIFF
--- a/OpenStack Summit/OpenStack Summit/EventViewController.swift
+++ b/OpenStack Summit/OpenStack Summit/EventViewController.swift
@@ -144,10 +144,6 @@ extension EventViewController {
         
         let newValue = !scheduled
         
-        guard eventRequestInProgress == false else { return }
-        
-        eventRequestInProgress = true
-        
         // different action based on conditions
         switch (newValue, rsvpURL, externalRSVP) {
             
@@ -249,6 +245,8 @@ extension EventViewController {
             
             self.setScheduledLocally(cacheValue, for: event.identifier)
         }
+        
+        eventRequestInProgress = true
         
         // make API request
         request(summit: event.summit, event: event.identifier, completion: completion)

--- a/OpenStack Summit/OpenStack Summit/ScheduleView.xib
+++ b/OpenStack Summit/OpenStack Summit/ScheduleView.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11542" systemVersion="16D32" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11542" systemVersion="16E195" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
     <device id="retina4_0" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
@@ -10,6 +10,9 @@
     <customFonts key="customFonts">
         <array key="OpenSans-Regular.ttf">
             <string>OpenSans</string>
+        </array>
+        <array key="OpenSans-Semibold.ttf">
+            <string>OpenSans-Semibold</string>
         </array>
     </customFonts>
     <objects>
@@ -41,7 +44,7 @@
                     <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                 </tableView>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="There are no added events so far." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7UD-xN-OK6">
-                    <rect key="frame" x="30" y="252" width="261" height="65.5"/>
+                    <rect key="frame" x="30" y="251.5" width="261" height="65.5"/>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                     <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="24"/>
                     <color key="textColor" red="0.60784313725490191" green="0.60784313725490191" blue="0.60784313725490191" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -51,9 +54,12 @@
                     <rect key="frame" x="0.0" y="0.0" width="60" height="52"/>
                     <subviews>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wis-wA-eYi">
-                            <rect key="frame" x="12" y="11" width="37" height="30"/>
+                            <rect key="frame" x="11.5" y="9.5" width="38" height="33"/>
                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                            <state key="normal" title="NOW"/>
+                            <fontDescription key="fontDescription" name="OpenSans-Semibold" family="Open Sans" pointSize="15"/>
+                            <state key="normal" title="NOW">
+                                <color key="titleColor" red="0.29019607843137252" green="0.29019607843137252" blue="0.29019607843137252" alpha="1" colorSpace="calibratedRGB"/>
+                            </state>
                         </button>
                     </subviews>
                     <color key="backgroundColor" red="0.89803921568627454" green="0.89803921568627454" blue="0.89803921568627454" alpha="1" colorSpace="calibratedRGB"/>


### PR DESCRIPTION
- When event has internal RSVP, clicking unRSVP button needs to ping the unRSVP endpoint (replacing the unSCHEDULE call since its done automatically by the server). In this case, we dont need to redirect to RSVP link.
- When event has external RSVP, clicking unRSVP button pings unSCHEDULE endpoint. In this case, we do redirect to RSVP link (so, external RSVP redirects both when doing RSVP and unRSVP)
- The internal RSVP web can do a redirect back to the app when BackURL querystring param present.