### PR TITLE
[12773] NOW and schedule functionality update

### DIFF
--- a/OpenStack Summit/CoreSummit/Compound.swift
+++ b/OpenStack Summit/CoreSummit/Compound.swift
@@ -133,7 +133,6 @@ infix operator ||| {
 
 public func &&& (lhs: Predicate, rhs: Predicate) -> Predicate {
     
-    let value = true && false
     return .compound(.and([lhs, rhs]))
 }
 

--- a/OpenStack Summit/OpenStack Summit/Filter.swift
+++ b/OpenStack Summit/OpenStack Summit/Filter.swift
@@ -151,8 +151,10 @@ struct ScheduleFilter: Equatable {
             // dont want to override selection
             if didChangeActiveTalks == false {
                 
+                // During summit time jump to NOW as default, overriding Summit start date logic
+                
                 // start hiding active talks
-                activeFilters.insert(.activeTalks)
+                //activeFilters.insert(.activeTalks)
             }
         }
         else {

--- a/OpenStack Summit/OpenStack Summit/ScheduleItem.swift
+++ b/OpenStack Summit/OpenStack Summit/ScheduleItem.swift
@@ -9,6 +9,7 @@
 import Foundation
 import CoreSummit
 import CoreData
+import struct SwiftFoundation.Date
 
 public struct ScheduleItem: CoreDataDecodable {
     
@@ -17,6 +18,8 @@ public struct ScheduleItem: CoreDataDecodable {
     public let identifier: Identifier
     public let name: String
     public let summit: Identifier
+    public let start: Date
+    public let end: Date
     public let dateTime: String
     public let time: String
     public let location: String
@@ -32,6 +35,8 @@ public struct ScheduleItem: CoreDataDecodable {
         self.identifier = event.identifier
         self.name = event.name
         self.summit = event.summit.identifier
+        self.start = Date(foundation: event.start)
+        self.end = Date(foundation: event.end)
         self.eventType = event.eventType.name
         self.location = ScheduleItem.getLocation(event)
         self.dateTime = ScheduleItem.getDateTime(event)

--- a/OpenStack Summit/OpenStack Summit/ScheduleViewController.swift
+++ b/OpenStack Summit/OpenStack Summit/ScheduleViewController.swift
@@ -123,6 +123,9 @@ class ScheduleViewController: UIViewController, EventViewController, MessageEnab
         guard let today = self.availableDates.firstMatching({ $0.mt_isWithinSameDay(now) })
             else { return }
         
+        guard let _ = nowEventIndex()
+            else { showErrorAlert("All presentations are finished for today."); return }
+        
         (self.scheduleView.dayPicker.valueForKey("daysCollectionView") as! UICollectionView).reloadData()
         
         self.nowSelected = true
@@ -393,6 +396,14 @@ class ScheduleViewController: UIViewController, EventViewController, MessageEnab
         self.loadData()
     }
     
+    @inline(__always)
+    private func nowEventIndex() -> Int? {
+        
+        let now = Date()
+        
+        return self.dayEvents.indexOf({ $0.end >= now && $0.track != "General" })
+    }
+    
     // MARK: - AFHorizontalDayPickerDelegate
     
     func horizontalDayPicker(picker: AFHorizontalDayPicker, widthForItemWithDate date: NSDate) -> CGFloat {
@@ -417,10 +428,7 @@ class ScheduleViewController: UIViewController, EventViewController, MessageEnab
             
             if nowSelected {
                 
-                let now = Date()
-                
-                guard let currentEventIndex = self.dayEvents.indexOf({ $0.end >= now })
-                    else { fatalError("Cannot jump to current event for NOW/n\(NSDate())\n\(dayEvents)") }
+                let currentEventIndex = nowEventIndex() ?? 0
                 
                 indexPath = NSIndexPath(forRow: currentEventIndex, inSection: 0)
                 

--- a/OpenStack Summit/OpenStack Summit/ScheduleViewController.swift
+++ b/OpenStack Summit/OpenStack Summit/ScheduleViewController.swift
@@ -116,23 +116,30 @@ class ScheduleViewController: UIViewController, EventViewController, MessageEnab
     
     // MARK: - Actions
     
-    @IBAction func nowTapped(sender: UIButton) {
+    @IBAction func nowTapped(sender: AnyObject? = nil) {
         
         let now = NSDate()
         
         guard let today = self.availableDates.firstMatching({ $0.mt_isWithinSameDay(now) })
             else { return }
         
-        guard let _ = nowEventIndex()
-            else { showErrorAlert("All presentations are finished for today."); return }
-        
         (self.scheduleView.dayPicker.valueForKey("daysCollectionView") as! UICollectionView).reloadData()
         
         self.nowSelected = true
+        
+        let oldSelectedDate = self.selectedDate
+        
+        if oldSelectedDate != today {
+            
+            reloadSchedule()
+        }
                 
         self.selectedDate = today
         
         self.nowSelected = false
+        
+        guard let _ = nowEventIndex()
+            else { showInfoMessage("", message: "All presentations are finished for today."); return }
     }
     
     @IBAction func showEventContextMenu(sender: UIButton) {
@@ -233,7 +240,7 @@ class ScheduleViewController: UIViewController, EventViewController, MessageEnab
         
         let oldSelectedDate = self.selectedDate
         
-        if let defaultStart = summit.defaultStart?.toFoundation(),
+        if  let defaultStart = summit.defaultStart?.toFoundation(),
             let defaultDay = self.availableDates.firstMatching({ $0.mt_isWithinSameDay(defaultStart) })
             where summitActive == false && self.didSelectDate == false {
             
@@ -290,6 +297,15 @@ class ScheduleViewController: UIViewController, EventViewController, MessageEnab
         if oldSchedule.isEmpty {
             
             tableView.reloadData()
+            
+            NSOperationQueue.mainQueue().addOperationWithBlock {
+                
+                // jump to NOW
+                if self.scheduleView.nowButtonEnabled {
+                    
+                    self.nowTapped()
+                }
+            }
             
         } else {
             


### PR DESCRIPTION
Update schedule and NOW functionality as follows:
- Jump to the current day on the calendar tabs, and scroll to first event on the list where `EndDate >= GetDate()`
- Continue to obey the filters
- Don't disable any other calendar buttons
- If "Hide past events" is selected, continue to respect that filter
- Make sure "Hide past events" is still a filter in both Android and iOS
- Hide "Hide past events" should be set off by default during summit time (currently its set on by default)
- During summit time jump to NOW as default, overriding Summit start date logic
- if click NOW, but there is nothing else, display an alert pops up that says “All presentations are finished for today”
- Ignore `General` activities
