### PR TITLE
[iOS] [12861] Delete user notifications when logging out

### DIFF
--- a/OpenStack Summit/CoreSummit/Login.swift
+++ b/OpenStack Summit/CoreSummit/Login.swift
@@ -17,15 +17,21 @@ public extension Store {
         
         let context = privateQueueManagedObjectContext
         
-        // remove member from cache
+        // remove member-specific data from cache
         try! context.performErrorBlockAndWait {
             
+            // delete member
             if let member = try self.authenticatedMember(context) {
                 
                 context.deleteObject(member)
-                
-                try context.validateAndSave()
             }
+            
+            // delete all notifications except 'EVERYBODY' type
+            let notifications = try context.managedObjects(NotificationManagedObject.self, predicate: "channel" != CoreSummit.Notification.Channel.everyone.rawValue)
+            
+            notifications.forEach { context.deleteObject($0) }
+            
+            try context.validateAndSave()
         }
         
         session.clear()


### PR DESCRIPTION
A user is logged in and receives text messages in their inbox. The user logs out and a new user logs in. This new user can view the text messages from the previous user's account. There seems to be a cacheing issue here.