### PR TITLE
[12865] [12868] Push Notification Fixes

### DIFF
--- a/OpenStack Summit/CoreSummit/Notification.swift
+++ b/OpenStack Summit/CoreSummit/Notification.swift
@@ -116,7 +116,7 @@ public extension Notification {
             
             func parseIdentifier(prefix: Prefix) -> Identifier? {
                 
-                let prefixString = "/topics/" + prefix.rawValue + "_"
+                let prefixString = "/topics/" + "ios_" + prefix.rawValue + "_"
                 
                 guard rawValue.containsString(prefixString) else { return nil }
                 
@@ -156,7 +156,7 @@ public extension Notification {
             
             func parseCollection() -> Topic? {
                 
-                let prefixString = rawValue.stringByReplacingOccurrencesOfString("/topics/", withString: "")
+                let prefixString = rawValue.stringByReplacingOccurrencesOfString("/topics/ios_", withString: "")
                 
                 guard let prefix = Prefix(rawValue: prefixString)
                     else { return nil }
@@ -199,7 +199,7 @@ public extension Notification {
         
         public var rawValue: String {
             
-            var stringValue = "/topics/" + Prefix(self).rawValue
+            var stringValue = "/topics/ios_" + Prefix(self).rawValue
             
             if let identifier = self.identifier {
                 

--- a/OpenStack Summit/OpenStack Summit/AppDelegate.swift
+++ b/OpenStack Summit/OpenStack Summit/AppDelegate.swift
@@ -136,15 +136,24 @@ final class AppDelegate: UIResponder, UIApplicationDelegate, SummitActivityHandl
         
         print("APNs token retrieved: \(deviceToken)")
         
-        FIRInstanceID.instanceID().setAPNSToken(deviceToken, type: FIRInstanceIDAPNSTokenType.Sandbox)
+        FIRInstanceID.instanceID().setAPNSToken(deviceToken, type: .Sandbox)
     }
     
     func application(application: UIApplication, didReceiveRemoteNotification userInfo: [NSObject : AnyObject], fetchCompletionHandler: (UIBackgroundFetchResult) -> ()) {
         
-        // called when push notification tapped
-        print("Tapped on remote notification: \(userInfo)")
-        
-        PushNotificationManager.shared.openedPushNotification = userInfo["gcm.message_id"] as? Identifier
+        // app was just brought from background to foreground
+        if application.applicationState == .Active {
+            
+            // called when push notification received in foreground
+            print("Recieved remote notification: \(userInfo)")
+            
+        } else {
+            
+            // called when push notification tapped
+            print("Tapped on remote notification: \(userInfo)")
+            
+            PushNotificationManager.shared.process(userInfo as! [String: AnyObject], unread: false)
+        }
         
         fetchCompletionHandler(.NoData)
     }

--- a/OpenStack Summit/OpenStack Summit/AppDelegate.swift
+++ b/OpenStack Summit/OpenStack Summit/AppDelegate.swift
@@ -153,6 +153,9 @@ final class AppDelegate: UIResponder, UIApplicationDelegate, SummitActivityHandl
             print("Tapped on remote notification: \(userInfo)")
             
             PushNotificationManager.shared.process(userInfo as! [String: AnyObject], unread: false)
+            
+            // redirect to inbox
+            menuViewController.showInbox()
         }
         
         fetchCompletionHandler(.NoData)

--- a/OpenStack Summit/OpenStack Summit/AppDelegate.swift
+++ b/OpenStack Summit/OpenStack Summit/AppDelegate.swift
@@ -110,9 +110,7 @@ final class AppDelegate: UIResponder, UIApplicationDelegate, SummitActivityHandl
         // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
         // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
         
-        #if !DEBUG
         FIRMessaging.messaging().disconnect()
-        #endif
     }
 
     func applicationWillEnterForeground(application: UIApplication) {
@@ -141,14 +139,14 @@ final class AppDelegate: UIResponder, UIApplicationDelegate, SummitActivityHandl
         FIRInstanceID.instanceID().setAPNSToken(deviceToken, type: FIRInstanceIDAPNSTokenType.Sandbox)
     }
     
-    func application(application: UIApplication, didReceiveRemoteNotification userInfo: [NSObject : AnyObject]) {
+    func application(application: UIApplication, didReceiveRemoteNotification userInfo: [NSObject : AnyObject], fetchCompletionHandler: (UIBackgroundFetchResult) -> ()) {
         
         // called when push notification tapped
         print("Tapped on remote notification: \(userInfo)")
         
-        let notificationDictionary = userInfo as! [String: AnyObject]
+        PushNotificationManager.shared.openedPushNotification = userInfo["gcm.message_id"] as? Identifier
         
-        PushNotificationManager.shared.process(notificationDictionary)
+        fetchCompletionHandler(.NoData)
     }
     
     func application(application: UIApplication, handleActionWithIdentifier identifier: String?, forLocalNotification notification: UILocalNotification, withResponseInfo responseInfo: [NSObject : AnyObject], completionHandler: () -> Void) {

--- a/OpenStack Summit/OpenStack Summit/AppDelegate.swift
+++ b/OpenStack Summit/OpenStack Summit/AppDelegate.swift
@@ -141,40 +141,14 @@ final class AppDelegate: UIResponder, UIApplicationDelegate, SummitActivityHandl
         FIRInstanceID.instanceID().setAPNSToken(deviceToken, type: FIRInstanceIDAPNSTokenType.Sandbox)
     }
     
-    // HACK: implemented old delegate to make notifications work as is on iOS 10
     func application(application: UIApplication, didReceiveRemoteNotification userInfo: [NSObject : AnyObject]) {
         
-        // Print message ID.
-        if let messageID = userInfo["gcm.message_id"] {
-            print("Message ID: \(messageID)")
-        }
+        // called when push notification tapped
+        print("Tapped on remote notification: \(userInfo)")
         
-        // Print full message.
-        print("Recieved remote notification: \(userInfo)")
+        let notificationDictionary = userInfo as! [String: AnyObject]
         
-        PushNotificationManager.shared.process(userInfo as! [String: AnyObject])
-    }
-    
-    func application(application: UIApplication, didReceiveRemoteNotification userInfo: [NSObject : AnyObject], fetchCompletionHandler completionHandler: (UIBackgroundFetchResult) -> Void) {
-        // If you are receiving a notification message while your app is in the background,
-        // this callback will not be fired till the user taps on the notification launching the application.
-        
-        // Print message ID.
-        if let messageID = userInfo["gcm.message_id"] {
-            print("Message ID: \(messageID)")
-        }
-        
-        // Print full message.
-        print("Recieved remote notification: \(userInfo)")
-        
-        var notification = userInfo
-        notification.removeValueForKey("aps")
-        
-        if let notificationDictionary = notification as? [String: AnyObject] {
-            PushNotificationManager.shared.process(notificationDictionary)
-        }
-        
-        completionHandler(.NewData)
+        PushNotificationManager.shared.process(notificationDictionary)
     }
     
     func application(application: UIApplication, handleActionWithIdentifier identifier: String?, forLocalNotification notification: UILocalNotification, withResponseInfo responseInfo: [NSObject : AnyObject], completionHandler: () -> Void) {

--- a/OpenStack Summit/OpenStack Summit/MenuViewController.swift
+++ b/OpenStack Summit/OpenStack Summit/MenuViewController.swift
@@ -217,6 +217,8 @@ final class MenuViewController: UIViewController, UITextFieldDelegate, ActivityV
     
     private func highlight(item: MenuItem) {
         
+        let _ = self.view
+        
         unselectMenuItems()
         
         switch item {


### PR DESCRIPTION
This would prevent duplicate notification when notification received is a non silent notification.
App should handle both scenarios.
if its a silent notification and in background, issue local and cache.
if its a proper notification and in background, just cache.
The sending of a silent notification requires a special configuration of the notification’s payload. If your payload is not configured properly, the notification might be displayed to the user instead of being delivered to your app in the background. In your payload, make sure the following conditions are true:
The payload’s aps dictionary must include the content-available key with a value of 1.
The payload’s aps dictionary must not contain the alert, sound, or badge keys.