### PR TITLE
[iOS] [12857] Fixed invalid user logged in

### DIFF
--- a/OpenStack Summit/CoreSummit/Login.swift
+++ b/OpenStack Summit/CoreSummit/Login.swift
@@ -59,7 +59,6 @@ public extension Store {
                     
                 case let .Value(member):
                     
-                    self.session.name = member.name
                     self.session.member = member.identifier
                     
                     completion(nil)

--- a/OpenStack Summit/CoreSummit/Session.swift
+++ b/OpenStack Summit/CoreSummit/Session.swift
@@ -9,9 +9,6 @@
 /// Provides the storage for session values
 public protocol SessionStorage {
     
-    /// The name of the authenticated user.
-    var name: String? { get set }
-    
     /// The authenticated member.
     var member: Identifier?  { get set }
     
@@ -24,7 +21,6 @@ public extension SessionStorage {
     /// Resets the session storage.
     mutating func clear() {
         
-        self.name = nil
         self.member = nil
     }
 }
@@ -55,21 +51,6 @@ public final class UserDefaultsSessionStorage: SessionStorage {
         }
     }
     
-    public var name: String? {
-        
-        get { return userDefaults.stringForKey(Key.name.rawValue) }
-        
-        set {
-            
-            guard let stringValue = newValue
-                else { userDefaults.removeObjectForKey(Key.name.rawValue); return }
-            
-            userDefaults.setObject(stringValue as NSString, forKey: Key.name.rawValue)
-            
-            userDefaults.synchronize()
-        }
-    }
-    
     public var hadPasscode: Bool {
         
         get { return userDefaults.boolForKey(Key.hadPasscode.rawValue) }
@@ -80,7 +61,6 @@ public final class UserDefaultsSessionStorage: SessionStorage {
     private enum Key: String {
         
         case member = "CoreSummit.UserDefaultsSessionStorage.Key.Member"
-        case name = "CoreSummit.UserDefaultsSessionStorage.Key.Name"
         case hadPasscode = "CoreSummit.UserDefaultsSessionStorage.Key.HadPasscode"
     }
 }

--- a/OpenStack Summit/OpenStack Summit/MenuViewController.swift
+++ b/OpenStack Summit/OpenStack Summit/MenuViewController.swift
@@ -286,11 +286,6 @@ final class MenuViewController: UIViewController, UITextFieldDelegate, ActivityV
                 pictureURL = currentMember.pictureURL
             }
             
-        } else if Store.shared.isLoggedIn {
-            
-            name = Store.shared.session.name ?? ""
-            pictureURL = ""
-            
         } else {
             
             name = ""


### PR DESCRIPTION
The username and profile image in the menu was cached in user defaults. We should always show that info from the current user info stored in CoreData.