### PR TITLE
[CoreSummit] [12879] Implement parsing of topics with and without platform prefix

### DIFF
--- a/OpenStack Summit/CoreSummit/Notification.swift
+++ b/OpenStack Summit/CoreSummit/Notification.swift
@@ -108,15 +108,19 @@ public extension Notification {
             }
         }
         
-        public init?(rawValue: String) {
+        private static func parse(string: String, with prefix: String) -> Notification.Topic? {
+            
+            let rawValue = string
+            
+            let topicPrefixString = prefix
             
             struct Cache {
-                static var prefixRegularExpressions = [Prefix: NSRegularExpression]()
+                static var prefixRegularExpressions = [String: [Prefix: NSRegularExpression]]()
             }
             
             func parseIdentifier(prefix: Prefix) -> Identifier? {
                 
-                let prefixString = "/topics/" + "ios_" + prefix.rawValue + "_"
+                let prefixString = topicPrefixString + prefix.rawValue + "_"
                 
                 guard rawValue.containsString(prefixString) else { return nil }
                 
@@ -124,7 +128,21 @@ public extension Notification {
                 
                 let regularExpression: NSRegularExpression
                 
-                if let cached = Cache.prefixRegularExpressions[prefix] {
+                let regularExpressionsForPrefix: [Prefix: NSRegularExpression]
+                
+                if let cached = Cache.prefixRegularExpressions[topicPrefixString] {
+                    
+                    regularExpressionsForPrefix = cached
+                    
+                } else {
+                    
+                    regularExpressionsForPrefix = [Prefix: NSRegularExpression]()
+                    
+                    // create new cache for prefix
+                    Cache.prefixRegularExpressions[topicPrefixString] = regularExpressionsForPrefix
+                }
+                
+                if let cached = regularExpressionsForPrefix[prefix] {
                     
                     regularExpression = cached
                     
@@ -132,7 +150,8 @@ public extension Notification {
                     
                     regularExpression = try! NSRegularExpression(pattern: prefixString + "(\\d+)", options: [])
                     
-                    Cache.prefixRegularExpressions[prefix] = regularExpression
+                    // add to cache
+                    Cache.prefixRegularExpressions[topicPrefixString]![prefix] = regularExpression
                 }
                 
                 // run regex
@@ -156,7 +175,7 @@ public extension Notification {
             
             func parseCollection() -> Topic? {
                 
-                let prefixString = rawValue.stringByReplacingOccurrencesOfString("/topics/ios_", withString: "")
+                let prefixString = rawValue.stringByReplacingOccurrencesOfString(topicPrefixString, withString: "")
                 
                 guard let prefix = Prefix(rawValue: prefixString)
                     else { return nil }
@@ -173,23 +192,35 @@ public extension Notification {
             
             if let collectionTopic = parseCollection() {
                 
-                self = collectionTopic
+                return collectionTopic
                 
             } else if let identifier = parseIdentifier(.summit) {
                 
-                self = .summit(identifier)
+                return .summit(identifier)
                 
             } else if let identifier = parseIdentifier(.member) {
                 
-                self = .member(identifier)
+                return .member(identifier)
                 
             } else if let identifier = parseIdentifier(.event) {
                 
-                self = .event(identifier)
+                return .event(identifier)
                 
             } else if let identifier = parseIdentifier(.team) {
                 
-                self = .team(identifier)
+                return .team(identifier)
+                
+            } else {
+                
+                return nil
+            }
+        }
+        
+        public init?(rawValue: String) {
+            
+            if let topic = Topic.parse(rawValue, with: "/topics/ios_") ?? Topic.parse(rawValue, with: "/topics/") {
+                
+                self = topic
                 
             } else {
                 

--- a/OpenStack Summit/CoreSummitTests/ModelTests.swift
+++ b/OpenStack Summit/CoreSummitTests/ModelTests.swift
@@ -1,0 +1,33 @@
+//
+//  ModelTests.swift
+//  OpenStack Summit
+//
+//  Created by Alsey Coleman Miller on 5/5/17.
+//  Copyright © 2017 OpenStack. All rights reserved.
+//
+
+import XCTest
+import SwiftFoundation
+@testable import CoreSummit
+
+final class ModelTests: XCTestCase {
+
+    func testNotificationTopicParse() {
+        
+        // Valid strings
+        XCTAssert(Notification.Topic(rawValue: "/topics/ios_everyone") == Notification.Topic.everyone)
+        XCTAssert(Notification.Topic(rawValue: "/topics/everyone") == Notification.Topic.everyone)
+        XCTAssert(Notification.Topic(rawValue: "/topics/ios_member_1") == Notification.Topic.member(1))
+        XCTAssert(Notification.Topic(rawValue: "/topics/member_1") == Notification.Topic.member(1))
+        
+        // Invalid Strings
+        XCTAssert(Notification.Topic(rawValue: "/topics/ios_") == nil)
+        XCTAssert(Notification.Topic(rawValue: "/topics/") == nil)
+        XCTAssert(Notification.Topic(rawValue: "/topics") == nil)
+        XCTAssert(Notification.Topic(rawValue: "/topics/fakeTopic") == nil)
+        XCTAssert(Notification.Topic(rawValue: "/topics/ios_fakeTopic") == nil)
+        XCTAssert(Notification.Topic(rawValue: "/topics/ios_member_") == nil)
+        XCTAssert(Notification.Topic(rawValue: "/topics/ios_member_a") == nil)
+        XCTAssert(Notification.Topic(rawValue: "/topics/ios_member") == nil)
+    }
+}

--- a/OpenStack Summit/OpenStack Summit.xcodeproj/project.pbxproj
+++ b/OpenStack Summit/OpenStack Summit.xcodeproj/project.pbxproj
@@ -427,6 +427,10 @@
 		6E53B2A71D85340700641A8F /* SpeakerDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E53B2A61D85340700641A8F /* SpeakerDetailViewController.swift */; };
 		6E53B2A91D8534F600641A8F /* SpeakerSearchResultsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E53B2A81D8534F600641A8F /* SpeakerSearchResultsViewController.swift */; };
 		6E53B2AB1D85366400641A8F /* SpeakerDetail.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6E53B2AA1D85366400641A8F /* SpeakerDetail.storyboard */; };
+		6E55B4EB1EBCA3D2003AAFE6 /* ModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E55B4EA1EBCA3D2003AAFE6 /* ModelTests.swift */; };
+		6E55B4EC1EBCA3D2003AAFE6 /* ModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E55B4EA1EBCA3D2003AAFE6 /* ModelTests.swift */; };
+		6E55B4ED1EBCA3D2003AAFE6 /* ModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E55B4EA1EBCA3D2003AAFE6 /* ModelTests.swift */; };
+		6E55B4EE1EBCA3D2003AAFE6 /* ModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E55B4EA1EBCA3D2003AAFE6 /* ModelTests.swift */; };
 		6E570A311D676A3800189992 /* DataUpdates2.json in Resources */ = {isa = PBXBuildFile; fileRef = 6E570A301D676A3800189992 /* DataUpdates2.json */; };
 		6E570A341D6771CF00189992 /* EventDataUpdate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E570A331D6771CF00189992 /* EventDataUpdate.swift */; };
 		6E570A361D67753D00189992 /* PresentationDataUpdate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E570A351D67753D00189992 /* PresentationDataUpdate.swift */; };
@@ -1494,6 +1498,7 @@
 		6E53B2A61D85340700641A8F /* SpeakerDetailViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpeakerDetailViewController.swift; sourceTree = "<group>"; };
 		6E53B2A81D8534F600641A8F /* SpeakerSearchResultsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpeakerSearchResultsViewController.swift; sourceTree = "<group>"; };
 		6E53B2AA1D85366400641A8F /* SpeakerDetail.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = SpeakerDetail.storyboard; sourceTree = "<group>"; };
+		6E55B4EA1EBCA3D2003AAFE6 /* ModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ModelTests.swift; sourceTree = "<group>"; };
 		6E570A301D676A3800189992 /* DataUpdates2.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = DataUpdates2.json; sourceTree = "<group>"; };
 		6E570A331D6771CF00189992 /* EventDataUpdate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventDataUpdate.swift; sourceTree = "<group>"; };
 		6E570A351D67753D00189992 /* PresentationDataUpdate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PresentationDataUpdate.swift; sourceTree = "<group>"; };
@@ -2073,6 +2078,7 @@
 				6E0FD0AF1E92A7DB000C6DBA /* PredicateTests.swift */,
 				6E52FCBA1D130553006A7302 /* StoreTests.swift */,
 				6E10A5111D10672D008CBD0C /* TestUtilities.swift */,
+				6E55B4EA1EBCA3D2003AAFE6 /* ModelTests.swift */,
 				6E10A5031D1066E9008CBD0C /* Info.plist */,
 			);
 			path = CoreSummitTests;
@@ -4033,6 +4039,7 @@
 				6E574B6C1DCB2DFB00AE4837 /* CoreDataTests.swift in Sources */,
 				6E0B5F241D77C8AB0005F6CE /* TestUtilities.swift in Sources */,
 				6E0B5F251D77C8AB0005F6CE /* JSONTests.swift in Sources */,
+				6E55B4EE1EBCA3D2003AAFE6 /* ModelTests.swift in Sources */,
 				6E0FD0B31E92A7DB000C6DBA /* PredicateTests.swift in Sources */,
 				6E0B5F261D77C8AB0005F6CE /* StoreTests.swift in Sources */,
 			);
@@ -4348,6 +4355,7 @@
 				6E574B6E1DCB2DFD00AE4837 /* CoreDataTests.swift in Sources */,
 				6E10A5141D10672D008CBD0C /* TestUtilities.swift in Sources */,
 				6E10A5121D10672D008CBD0C /* JSONTests.swift in Sources */,
+				6E55B4EB1EBCA3D2003AAFE6 /* ModelTests.swift in Sources */,
 				6E0FD0B01E92A7DB000C6DBA /* PredicateTests.swift in Sources */,
 				6E52FCBB1D130553006A7302 /* StoreTests.swift in Sources */,
 			);
@@ -4525,6 +4533,7 @@
 				6E574B6D1DCB2DFC00AE4837 /* CoreDataTests.swift in Sources */,
 				6E2924171D7AF8CC00D14F0A /* TestUtilities.swift in Sources */,
 				6E2924181D7AF8CC00D14F0A /* JSONTests.swift in Sources */,
+				6E55B4ED1EBCA3D2003AAFE6 /* ModelTests.swift in Sources */,
 				6E0FD0B21E92A7DB000C6DBA /* PredicateTests.swift in Sources */,
 				6E2924191D7AF8CC00D14F0A /* StoreTests.swift in Sources */,
 			);
@@ -4718,6 +4727,7 @@
 				6E7558491E58C4A7003B6844 /* CoreDataTests.swift in Sources */,
 				6E75584A1E58C4A7003B6844 /* TestUtilities.swift in Sources */,
 				6E75584B1E58C4A7003B6844 /* JSONTests.swift in Sources */,
+				6E55B4EC1EBCA3D2003AAFE6 /* ModelTests.swift in Sources */,
 				6E0FD0B11E92A7DB000C6DBA /* PredicateTests.swift in Sources */,
 				6E75584C1E58C4A7003B6844 /* StoreTests.swift in Sources */,
 			);


### PR DESCRIPTION
Currently topics are sent with platform prefix (/topics/ios_everyone)
If install is stuck with a record containing the old way we handled
topics (/topics/everyone), retrieving notification from core data will
fail. This will crash the app when entering inbox section.
Implement patch to parse topic with and without platform prefix.