### PR TITLE
Replace `NSPredicate` with `Predicate`

### DIFF
--- a/OpenStack Summit/CoreSummit/CoreDataDecodable.swift
+++ b/OpenStack Summit/CoreSummit/CoreDataDecodable.swift
@@ -34,17 +34,29 @@ public extension NSManagedObjectContext {
     }
     
     @inline(__always)
-    func managedObjects<T: CoreDataDecodable>(_ decodableType: T.Type, predicate: NSPredicate? = nil, sortDescriptors: [NSSortDescriptor] = [], limit: Int = 0) throws -> [T] {
+    func managedObjects<T: CoreDataDecodable>(_ decodableType: T.Type,
+                        predicate: NSPredicate? = nil,
+                        sortDescriptors: [NSSortDescriptor] = [],
+                        limit: Int = 0) throws -> [T] {
         
-        let results = try self.managedObjects(decodableType.ManagedObject.self, predicate: predicate, sortDescriptors: sortDescriptors, limit: limit)
+        let results = try self.managedObjects(decodableType.ManagedObject.self,
+                                              predicate: predicate,
+                                              sortDescriptors: sortDescriptors,
+                                              limit: limit)
         
         return T.from(managedObjects: results)
     }
     
     @inline(__always)
-    func managedObjects<T: CoreDataDecodable>(_ decodableType: T.Type, predicate: Predicate, sortDescriptors: [NSSortDescriptor] = []) throws -> [T] {
+    func managedObjects<T: CoreDataDecodable>(_ decodableType: T.Type,
+                        predicate: Predicate,
+                        sortDescriptors: [NSSortDescriptor] = [],
+                        limit: Int = 0) throws -> [T] {
         
-        let results = try self.managedObjects(decodableType.ManagedObject.self, predicate: predicate, sortDescriptors: sortDescriptors)
+        let results = try self.managedObjects(decodableType.ManagedObject.self,
+                                              predicate: predicate.toFoundation(),
+                                              sortDescriptors: sortDescriptors,
+                                              limit: limit)
         
         return T.from(managedObjects: results)
     }
@@ -83,7 +95,7 @@ public extension NSFetchedResultsController {
 public func NSFetchedResultsController <T: CoreDataDecodable>
     (_ decodable: T.Type,
      delegate: NSFetchedResultsControllerDelegate? = nil,
-     predicate: NSPredicate? = nil,
+     predicate: Predicate? = nil,
      sortDescriptors: [NSSortDescriptor] = [],
      sectionNameKeyPath: String? = nil,
      context: NSManagedObjectContext) -> NSFetchedResultsController<T.ManagedObject> {
@@ -94,7 +106,7 @@ public func NSFetchedResultsController <T: CoreDataDecodable>
     
     let fetchRequest = NSFetchRequest<T.ManagedObject>(entityName: entity.name!)
     
-    fetchRequest.predicate = predicate
+    fetchRequest.predicate = predicate?.toFoundation()
     
     fetchRequest.sortDescriptors = sortDescriptors
     

--- a/OpenStack Summit/CoreSummit/EventManagedObject.swift
+++ b/OpenStack Summit/CoreSummit/EventManagedObject.swift
@@ -55,6 +55,10 @@ public final class EventManagedObject: Entity {
     @NSManaged public var groups: Set<GroupManagedObject>
     
     @NSManaged public var summit: SummitManagedObject
+    
+    // MARK: - Inverse Relationhips
+    
+    @NSManaged public var attendees: Set<AttendeeManagedObject>
 }
 
 // MARK: - Encoding

--- a/OpenStack Summit/CoreSummit/EventManagedObject.swift
+++ b/OpenStack Summit/CoreSummit/EventManagedObject.swift
@@ -178,6 +178,7 @@ public extension EventManagedObject {
         
         //let predicate = NSPredicate(format: "name CONTAINS [c] %@ or ANY presentation.speakers.firstName CONTAINS [c] %@ or ANY presentation.speakers.lastName CONTAINS [c] %@ or presentation.level CONTAINS [c] %@ or ANY tags.name CONTAINS [c] %@ or eventType.name CONTAINS [c] %@", searchTerm, searchTerm, searchTerm, searchTerm, searchTerm, searchTerm)
         let predicate: Predicate = (#keyPath(EventManagedObject.name)).compare(.contains, [.caseInsensitive], value)
+            || (#keyPath(EventManagedObject.presentation.speakers.firstName)).compare(.any, .contains, [.caseInsensitive], value)
             || (#keyPath(EventManagedObject.presentation.speakers.lastName)).compare(.any, .contains, [.caseInsensitive], value)
             || (#keyPath(EventManagedObject.presentation.level)).compare(.contains, [.caseInsensitive], value)
             || (#keyPath(EventManagedObject.tags.name)).compare(.any, .contains, [.caseInsensitive], value)
@@ -259,7 +260,7 @@ public extension EventManagedObject {
         
         assert(predicates.count > 1)
         
-        return try context.managedObjects(EventManagedObject.self,
+        return try context.managedObjects(self,
                                           predicate: .compound(.and(predicates)),
                                           sortDescriptors: sortDescriptors)
     }
@@ -273,7 +274,7 @@ public extension EventManagedObject {
             && #keyPath(EventManagedObject.end) <= end
             && #keyPath(EventManagedObject.summit.id) == summit
         
-        return try context.managedObjects(EventManagedObject.self, predicate: predicate, sortDescriptors: sortDescriptors)
+        return try context.managedObjects(self, predicate: predicate, sortDescriptors: sortDescriptors)
     }
 }
 

--- a/OpenStack Summit/CoreSummit/SpeakerManagedObject.swift
+++ b/OpenStack Summit/CoreSummit/SpeakerManagedObject.swift
@@ -82,70 +82,11 @@ extension Speaker: CoreDataEncodable {
 
 public extension SpeakerManagedObject {
     
-    public enum Property: String {
-        
-        case id, firstName, lastName, addressBookSectionName, title, pictureURL, twitter, irc, biography, member
-    }
-    
     static var sortDescriptors: [NSSortDescriptor] {
         
-        return [NSSortDescriptor(key: Property.addressBookSectionName.rawValue, ascending: true),
-                NSSortDescriptor(key: Property.firstName.rawValue, ascending: true),
-                NSSortDescriptor(key: Property.lastName.rawValue, ascending: true),
-                NSSortDescriptor(key: Property.id.rawValue, ascending: true)]
-    }
-}
-
-public extension Speaker {
-    
-    static func filter(_ searchTerm: String = "",
-                       page: Int, objectsPerPage: Int,
-                       summit: Identifier? = nil,
-                       context: NSManagedObjectContext) throws -> [Speaker] {
-        
-        var predicates = [NSPredicate]()
-        
-        if searchTerm.isEmpty == false {
-            
-            let searchPredicate = NSPredicate(format: "firstName CONTAINS[c] %@ OR lastName CONTAINS[c] %@", searchTerm, searchTerm)
-            
-            predicates.append(searchPredicate)
-        }
-        
-        if let summitID = summit,
-            let summit = try SummitManagedObject.find(summitID, context: context) {
-            
-            let summitPredicate = NSPredicate(format: "%@ IN summits", summit)
-            
-            predicates.append(summitPredicate)
-        }
-        
-        let predicate: NSPredicate?
-        
-        if predicates.count > 1 {
-            
-            predicate = NSCompoundPredicate(andPredicateWithSubpredicates: predicates)
-            
-        } else {
-            
-            predicate = predicates.first
-        }
-        
-        let results = try context.managedObjects(ManagedObject.self, predicate: predicate, sortDescriptors: ManagedObject.sortDescriptors)
-        
-        var speakers = [ManagedObject]()
-        
-        let startRecord = (page - 1) * objectsPerPage
-        
-        let endRecord = (startRecord + (objectsPerPage - 1)) <= results.count ? startRecord + (objectsPerPage - 1) : results.count - 1
-        
-        if (startRecord <= endRecord) {
-            
-            for index in (startRecord...endRecord) {
-                speakers.append(results[index])
-            }
-        }
-        
-        return Speaker.from(managedObjects: speakers)
+        return [NSSortDescriptor(key: #keyPath(addressBookSectionName), ascending: true),
+                NSSortDescriptor(key:#keyPath(SpeakerManagedObject.firstName), ascending: true),
+                NSSortDescriptor(key:#keyPath(SpeakerManagedObject.lastName), ascending: true),
+                NSSortDescriptor(key:#keyPath(SpeakerManagedObject.id), ascending: true)]
     }
 }

--- a/OpenStack Summit/CoreSummit/TagManagedObject.swift
+++ b/OpenStack Summit/CoreSummit/TagManagedObject.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import CoreData
+import Predicate
 
 public final class TagManagedObject: Entity {
     
@@ -53,10 +54,9 @@ public extension Tag {
     
     static func search(_ searchTerm: String, context: NSManagedObjectContext) throws -> [Tag] {
         
-        let predicate = NSPredicate(format: "name CONTAINS[c] %@", searchTerm)
+        //let predicate = NSPredicate(format: "name CONTAINS[c] %@", searchTerm)
+        let predicate: Predicate = (#keyPath(TagManagedObject.name)).compare(.contains, [.caseInsensitive], .value(.string(searchTerm)))
         
-        let managedObjects = try context.managedObjects(ManagedObject.self, predicate: predicate, sortDescriptors: ManagedObject.sortDescriptors)
-        
-        return Tag.from(managedObjects: managedObjects)
+        return try context.managedObjects(self, predicate: predicate, sortDescriptors: ManagedObject.sortDescriptors)
     }
 }

--- a/OpenStack Summit/CoreSummit/TrackGroupManagedObject.swift
+++ b/OpenStack Summit/CoreSummit/TrackGroupManagedObject.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import CoreData
+import Predicate
 
 public final class TrackGroupManagedObject: Entity {
     
@@ -57,7 +58,7 @@ public extension TrackGroupManagedObject {
     
     static var sortDescriptors: [NSSortDescriptor] {
         
-        return [NSSortDescriptor(key: "name", ascending: true)]
+        return [NSSortDescriptor(key: #keyPath(TrackGroupManagedObject.name), ascending: true)]
     }
 }
 
@@ -66,15 +67,8 @@ public extension TrackGroup {
     /// Fetch all track groups that have some event associated with them.
     static func scheduled(for summit: Identifier, context: NSManagedObjectContext) throws -> [TrackGroup] {
         
-        guard let summitManagedObject = try SummitManagedObject.find(summit, context: context)
-            else { return [] }
+        let predicate: Predicate = #keyPath(TrackGroupManagedObject.tracks.events) + ".@count" > 0
         
-        let events = try context.managedObjects(EventManagedObject.self, predicate: NSPredicate(format: "track != nil AND summit == %@", summitManagedObject))
-        
-        var groups = events.reduce([TrackGroupManagedObject](), { $0.0 + Array($0.1.track!.groups) })
-                
-        groups = (Set(groups) as NSSet).sortedArray(using: ManagedObject.sortDescriptors) as! [TrackGroupManagedObject]
-        
-        return TrackGroup.from(managedObjects: groups)
+        return try context.managedObjects(self, predicate: predicate, sortDescriptors: ManagedObject.sortDescriptors)
     }
 }

--- a/OpenStack Summit/CoreSummit/TrackGroupManagedObject.swift
+++ b/OpenStack Summit/CoreSummit/TrackGroupManagedObject.swift
@@ -19,6 +19,10 @@ public final class TrackGroupManagedObject: Entity {
     @NSManaged public var color: String
     
     @NSManaged public var tracks: Set<TrackManagedObject>
+    
+    // Inverse Relationships
+    
+    @NSManaged public var summits: Set<SummitManagedObject>
 }
 
 // MARK: - Encoding
@@ -68,6 +72,7 @@ public extension TrackGroup {
     static func scheduled(for summit: Identifier, context: NSManagedObjectContext) throws -> [TrackGroup] {
         
         let predicate: Predicate = #keyPath(TrackGroupManagedObject.tracks.events) + ".@count" > 0
+            && (#keyPath(TrackGroupManagedObject.summits)).compare(.contains, .value(.int64(summit)))
         
         return try context.managedObjects(self, predicate: predicate, sortDescriptors: ManagedObject.sortDescriptors)
     }

--- a/OpenStack Summit/OpenStack Summit/Filter.swift
+++ b/OpenStack Summit/OpenStack Summit/Filter.swift
@@ -94,12 +94,14 @@ struct ScheduleFilter: Equatable {
         
         // fetch data
         let trackGroups = try! TrackGroup.scheduled(for: summitID, context: context)
-        let levels = try! Set(context.managedObjects(PresentationManagedObject.self, predicate: "event.summit.id" == summitID)
+        let levels = try! Set(context.managedObjects(PresentationManagedObject.self, predicate: #keyPath(PresentationManagedObject.event.summit.id) == summitID)
             .flatMap { $0.level })
             .flatMap { Level(rawValue: $0) }
             .sorted()
         
-        let venues = try! context.managedObjects(Venue.self, predicate: NSPredicate(format: "summit == %@", summit), sortDescriptors: VenueManagedObject.sortDescriptors)
+        let venues = try! context.managedObjects(Venue.self,
+                                                 predicate: #keyPath(VenueManagedObject.summit.id) == summitID,
+                                                 sortDescriptors: VenueManagedObject.sortDescriptors)
         
         // populate filter categories
         

--- a/OpenStack Summit/OpenStack Summit/GeneralScheduleFilterViewController.swift
+++ b/OpenStack Summit/OpenStack Summit/GeneralScheduleFilterViewController.swift
@@ -9,6 +9,7 @@
 import UIKit
 import Foundation
 import CoreSummit
+import Predicate
 
 final class GeneralScheduleFilterViewController: UITableViewController {
     
@@ -113,9 +114,10 @@ final class GeneralScheduleFilterViewController: UITableViewController {
         if let trackGroupsSection = scheduleFilter.allFilters[.trackGroup] {
             
             // fetch from CoreData because it caches fetch request results and is more efficient
-            let identifiers = trackGroupsSection.map { NSNumber(value: Int64(identifier(for: $0))) }
+            let identifiers = trackGroupsSection.map { identifier(for: $0) }
             
-            let predicate = NSPredicate(format: "id IN %@", identifiers)
+            //let predicate = NSPredicate(format: "id IN %@", identifiers)
+            let predicate: Predicate = (#keyPath(TrackGroupManagedObject.id)).in(identifiers)
             
             let trackGroups = try! context.managedObjects(TrackGroup.self, predicate: predicate, sortDescriptors: TrackGroup.ManagedObject.sortDescriptors)
             
@@ -134,9 +136,10 @@ final class GeneralScheduleFilterViewController: UITableViewController {
         if let venuesSection = scheduleFilter.allFilters[.venue] {
             
             // fetch from CoreData because it caches fetch request results and is more efficient
-            let identifiers = venuesSection.map { NSNumber(value: Int64(identifier(for: $0))) }
+            let identifiers = venuesSection.map { identifier(for: $0) }
             
-            let predicate = NSPredicate(format: "id IN %@", identifiers)
+            //let predicate = NSPredicate(format: "id IN %@", identifiers)
+            let predicate: Predicate = (#keyPath(VenueManagedObject.id)).in(identifiers)
             
             let venues = try! context.managedObjects(Venue.self, predicate: predicate, sortDescriptors: Venue.ManagedObject.sortDescriptors)
             

--- a/OpenStack Summit/OpenStack Summit/PushNotificationManager.swift
+++ b/OpenStack Summit/OpenStack Summit/PushNotificationManager.swift
@@ -356,11 +356,17 @@ public final class PushNotificationManager: NSObject, NSFetchedResultsController
             return
         }
         
-        let predicate = NSPredicate(format: "owner == %@ || members.member CONTAINS %@", member, member)
+        //let predicate = NSPredicate(format: "owner == %@ || members.member CONTAINS %@", member, member)
+        let predicate: Predicate = #keyPath(TeamManagedObject.owner.id) == member.id
+            || (#keyPath(TeamManagedObject.members.member.id)).compare(.contains, .value(.int64(member.id)))
         
-        let sort = [NSSortDescriptor(key: "id", ascending: true)]
+        let sort = [NSSortDescriptor(key: #keyPath(TeamManagedObject.id), ascending: true)]
         
-        teamsFetchedResultsController = NSFetchedResultsController(Team.self, delegate: self, predicate: predicate, sortDescriptors: sort, sectionNameKeyPath: nil, context: store.managedObjectContext)
+        teamsFetchedResultsController = NSFetchedResultsController(Team.self,
+                                                                   delegate: self,
+                                                                   predicate: predicate,
+                                                                   sortDescriptors: sort,
+                                                                   context: store.managedObjectContext)
         
         try! teamsFetchedResultsController!.performFetch()
         
@@ -385,11 +391,13 @@ public final class PushNotificationManager: NSObject, NSFetchedResultsController
             
             subscribe(to: .attendees)
             
-            let predicate = NSPredicate(format: "attendees CONTAINS %@", attendeeRole)
+            //let predicate = NSPredicate(format: "attendees CONTAINS %@", attendeeRole)
+            let predicate: Predicate = (#keyPath(EventManagedObject.attendees.id)).compare(.contains, .value(.int64(attendeeRole.id)))
             
-            let sort = [NSSortDescriptor(key: "id", ascending: true)]
-            
-            eventsFetchedResultsController = NSFetchedResultsController(Event.self, delegate: self, predicate: predicate, sortDescriptors: sort, sectionNameKeyPath: nil, context: store.managedObjectContext)
+            eventsFetchedResultsController = NSFetchedResultsController(Event.self,
+                                                                        delegate: self,
+                                                                        predicate: predicate,
+                                                                        context: store.managedObjectContext)
             
             try! eventsFetchedResultsController!.performFetch()
             
@@ -447,7 +455,8 @@ public final class PushNotificationManager: NSObject, NSFetchedResultsController
         let unreadTeamMessages = Array(self.unreadTeamMessages.value)
         
         //NSPredicate(format: "team.id == %@ AND id IN %@", NSNumber(longLong: Int64(team)), unreadTeamMessages)
-        let predicate: Predicate = "team.id" == team && "id".`in`(unreadTeamMessages)
+        let predicate: Predicate = #keyPath(TeamMessageManagedObject.team.id) == team
+            && (#keyPath(TeamMessageManagedObject.id)).in(unreadTeamMessages)
         
         return try context.count(TeamMessageManagedObject.self, predicate: predicate)
     }

--- a/OpenStack Summit/OpenStack Summit/ScheduleItem.swift
+++ b/OpenStack Summit/OpenStack Summit/ScheduleItem.swift
@@ -53,9 +53,9 @@ public extension ScheduleItem {
     
     static func search(_ searchTerm: String, context: NSManagedObjectContext) throws -> [ScheduleItem] {
         
-        let predicate = NSPredicate(format: "name CONTAINS [c] %@ OR ANY presentation.speakers.firstName CONTAINS [c] %@ OR ANY presentation.speakers.lastName CONTAINS [c] %@ OR presentation.level CONTAINS [c] %@ OR ANY tags.name CONTAINS [c] %@ OR eventType.name CONTAINS [c] %@", searchTerm, searchTerm, searchTerm, searchTerm, searchTerm, searchTerm)
+        let managedObjects = try EventManagedObject.search(searchTerm, context: context)
         
-        return try context.managedObjects(self, predicate: predicate, sortDescriptors: ManagedObject.sortDescriptors)
+        return ScheduleItem.from(managedObjects: managedObjects)
     }
 }
 

--- a/OpenStack Summit/OpenStack Summit/SpeakersViewController.swift
+++ b/OpenStack Summit/OpenStack Summit/SpeakersViewController.swift
@@ -29,8 +29,8 @@ final class SpeakersViewController: TableViewController, RevealViewController, I
         // configure fetched results controller
         self.fetchedResultsController = NSFetchedResultsController(Speaker.self,
                                                                    delegate: self,
-                                                                   sortDescriptors: Speaker.ManagedObject.sortDescriptors,
-                                                                   sectionNameKeyPath: Speaker.ManagedObject.Property.addressBookSectionName.rawValue,
+                                                                   sortDescriptors: SpeakerManagedObject.sortDescriptors,
+                                                                   sectionNameKeyPath: #keyPath(SpeakerManagedObject.addressBookSectionName),
                                                                    context: Store.shared.managedObjectContext) as! NSFetchedResultsController<NSManagedObject>
         
         self.fetchedResultsController.fetchRequest.fetchBatchSize = 30

--- a/OpenStack Summit/OpenStack Summit/TeamMessagesViewController.swift
+++ b/OpenStack Summit/OpenStack Summit/TeamMessagesViewController.swift
@@ -76,15 +76,15 @@ final class TeamMessagesViewController: SLKTextViewController, NSFetchedResultsC
         
         self.title = teamManagedObject.name
         
-        let predicate = NSPredicate(format: "team == %@", teamManagedObject)
+        //let predicate = NSPredicate(format: "team == %@", teamManagedObject)
+        let predicate = #keyPath(TeamMessageManagedObject.team.id) == self.team
         
-        let sortDescriptors = [NSSortDescriptor(key: "id", ascending: false)]
+        let sortDescriptors = [NSSortDescriptor(key: #keyPath(TeamMessageManagedObject.id), ascending: false)]
         
         self.fetchedResultsController = NSFetchedResultsController(TeamMessage.self,
                                                                    delegate: self,
                                                                    predicate: predicate,
                                                                    sortDescriptors: sortDescriptors,
-                                                                   sectionNameKeyPath: nil,
                                                                    context: Store.shared.managedObjectContext) as! NSFetchedResultsController<NSFetchRequestResult>
         
         try! self.fetchedResultsController!.performFetch()

--- a/OpenStack Summit/OpenStack Summit/TeamMessagesViewController.swift
+++ b/OpenStack Summit/OpenStack Summit/TeamMessagesViewController.swift
@@ -27,7 +27,7 @@ final class TeamMessagesViewController: SLKTextViewController, NSFetchedResultsC
     
     private(set) var sending = false
     
-    private var fetchedResultsController: NSFetchedResultsController<NSFetchRequestResult>!
+    private var fetchedResultsController: NSFetchedResultsController<TeamMessageManagedObject>!
     
     private lazy var placeholderMemberImage = #imageLiteral(resourceName: "generic-user-avatar")
     
@@ -75,7 +75,7 @@ final class TeamMessagesViewController: SLKTextViewController, NSFetchedResultsC
         guard let teamID = self.team
             else { fatalError("View controller not configured") }
         
-        guard let teamManagedObject = try! TeamManagedObject.find(self.team, context: Store.shared.managedObjectContext)
+        guard let teamManagedObject = try! TeamManagedObject.find(teamID, context: Store.shared.managedObjectContext)
             else { fatalError("Team not in cache") }
         
         self.title = teamManagedObject.name
@@ -89,7 +89,7 @@ final class TeamMessagesViewController: SLKTextViewController, NSFetchedResultsC
                                                                    delegate: self,
                                                                    predicate: predicate,
                                                                    sortDescriptors: sortDescriptors,
-                                                                   context: Store.shared.managedObjectContext) as! NSFetchedResultsController<NSFetchRequestResult>
+                                                                   context: Store.shared.managedObjectContext)
         
         try! self.fetchedResultsController!.performFetch()
         
@@ -98,7 +98,7 @@ final class TeamMessagesViewController: SLKTextViewController, NSFetchedResultsC
     
     private subscript (indexPath: IndexPath) -> TeamMessage {
         
-        let managedObject = self.fetchedResultsController!.object(at: indexPath) as! TeamMessageManagedObject
+        let managedObject = self.fetchedResultsController!.object(at: indexPath)
         
         return TeamMessage(managedObject: managedObject)
     }

--- a/OpenStack Summit/OpenStack Summit/TeamMessagesViewController.swift
+++ b/OpenStack Summit/OpenStack Summit/TeamMessagesViewController.swift
@@ -10,6 +10,7 @@ import Foundation
 import UIKit
 import CoreData
 import CoreSummit
+import Predicate
 import Haneke
 import SlackTextViewController
 
@@ -71,13 +72,16 @@ final class TeamMessagesViewController: SLKTextViewController, NSFetchedResultsC
     
     private func configureView() {
         
-        guard let teamManagedObject = try! TeamManagedObject.find(team, context: Store.shared.managedObjectContext)
+        guard let teamID = self.team
+            else { fatalError("View controller not configured") }
+        
+        guard let teamManagedObject = try! TeamManagedObject.find(self.team, context: Store.shared.managedObjectContext)
             else { fatalError("Team not in cache") }
         
         self.title = teamManagedObject.name
         
         //let predicate = NSPredicate(format: "team == %@", teamManagedObject)
-        let predicate = #keyPath(TeamMessageManagedObject.team.id) == self.team
+        let predicate: Predicate = #keyPath(TeamMessageManagedObject.team.id) == teamID
         
         let sortDescriptors = [NSSortDescriptor(key: #keyPath(TeamMessageManagedObject.id), ascending: false)]
         

--- a/OpenStack Summit/OpenStackSummit macOS/SpeakersViewController.swift
+++ b/OpenStack Summit/OpenStackSummit macOS/SpeakersViewController.swift
@@ -73,23 +73,27 @@ final class SpeakersViewController: NSViewController, NSFetchedResultsController
     
     private func configureView() {
         
-        let summitID = NSNumber(value: Int64(SummitManager.shared.summit.value))
+        let summitID = Expression.value(.int64(SummitManager.shared.summit.value))
         
         //let summitPredicate = NSPredicate(format: "summits.id CONTAINS %@", summitID)
-        let summitPredicate: Predicate = #keyPath(SpeakerManagedObject.summits.id).compare
+        let summitPredicate: Predicate = (#keyPath(SpeakerManagedObject.summits.id)).compare(.contains, summitID)
         
-        let searchPredicate: NSPredicate
+        let searchPredicate: Predicate
         
         if searchTerm.isEmpty {
             
-            searchPredicate = NSPredicate(value: true)
+            searchPredicate = .value(true)
             
         } else {
             
-            searchPredicate = NSPredicate(format: "firstName CONTAINS[c] %@ OR lastName CONTAINS[c] %@", searchTerm, searchTerm)
+            let value = Expression.value(.string(searchTerm))
+            
+            //searchPredicate = NSPredicate(format: "firstName CONTAINS[c] %@ OR lastName CONTAINS[c] %@", searchTerm, searchTerm)
+            searchPredicate = (#keyPath(SpeakerManagedObject.firstName)).compare(.contains, [.caseInsensitive], value)
+                || (#keyPath(SpeakerManagedObject.lastName)).compare(.contains, [.caseInsensitive], value)
         }
         
-        let predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [searchPredicate, summitPredicate])
+        let predicate: Predicate = .compound(.and([searchPredicate, summitPredicate]))
         
         self.fetchedResultsController = NSFetchedResultsController(Speaker.self,
                                                                    delegate: self,

--- a/OpenStack Summit/OpenStackSummit macOS/VenuesMapViewController.swift
+++ b/OpenStack Summit/OpenStackSummit macOS/VenuesMapViewController.swift
@@ -72,8 +72,8 @@ final class VenueMapViewController: NSViewController, MKMapViewDelegate, NSFetch
             && .keyPath(#keyPath(VenueManagedObject.longitude)) != .value(.null)
             && #keyPath(VenueManagedObject.summit.id) == SummitManager.shared.summit.value
         
-        let sort = [NSSortDescriptor(key: "venueType", ascending: true),
-                    NSSortDescriptor(key: "name", ascending: true)]
+        let sort = [NSSortDescriptor(key: #keyPath(VenueManagedObject.venueType), ascending: true),
+                    NSSortDescriptor(key: #keyPath(VenueManagedObject.name), ascending: true)]
         
         self.fetchedResultsController = NSFetchedResultsController(Venue.self,
                                                                    delegate: self,

--- a/OpenStack Summit/OpenStackSummit macOS/VenuesSplitViewController.swift
+++ b/OpenStack Summit/OpenStackSummit macOS/VenuesSplitViewController.swift
@@ -75,7 +75,7 @@ final class VenuesSplitViewController: NSSplitViewController, SearchableControll
         
         //let mapVenuesPredicate = NSPredicate(format: "latitude != nil AND longitude != nil")
         let mapVenuesPredicate: Predicate = #keyPath(VenueManagedObject.latitude) != .value(.null)
-            && #keyPath(VenueManagedObject.longitude) != .value(.null)
+            && (#keyPath(VenueManagedObject.longitude)) != .value(.null)
         
         let predicate: Predicate = .compound(.and([mapVenuesPredicate, searchPredicate]))
         

--- a/OpenStack Summit/OpenStackSummit macOS/VenuesSplitViewController.swift
+++ b/OpenStack Summit/OpenStackSummit macOS/VenuesSplitViewController.swift
@@ -74,8 +74,8 @@ final class VenuesSplitViewController: NSSplitViewController, SearchableControll
         }
         
         //let mapVenuesPredicate = NSPredicate(format: "latitude != nil AND longitude != nil")
-        let mapVenuesPredicate: Predicate = #keyPath(VenueManagedObject.latitude) != .value(.null)
-            && (#keyPath(VenueManagedObject.longitude)) != .value(.null)
+        let mapVenuesPredicate: Predicate = .keyPath(#keyPath(VenueManagedObject.latitude)) != .value(.null)
+            && .keyPath(#keyPath(VenueManagedObject.longitude)) != .value(.null)
         
         let predicate: Predicate = .compound(.and([mapVenuesPredicate, searchPredicate]))
         

--- a/OpenStack Summit/OpenStackSummitTV/EventsViewController.swift
+++ b/OpenStack Summit/OpenStackSummitTV/EventsViewController.swift
@@ -22,7 +22,7 @@ final class EventsViewController: UITableViewController, NSFetchedResultsControl
         didSet { if isViewLoaded { updateUI() } }
     }
     
-    private var fetchedResultsController: NSFetchedResultsController<NSFetchRequestResult>!
+    private var fetchedResultsController: NSFetchedResultsController<EventManagedObject>!
     
     private static let cachedPredicate: Predicate = (.keyPath(#keyPath(Entity.cached)) != .value(.null))
     
@@ -48,9 +48,9 @@ final class EventsViewController: UITableViewController, NSFetchedResultsControl
         
         self.fetchedResultsController = NSFetchedResultsController(Event.self,
                                                                    delegate: self,
-                                                                   predicate: predicate.toFoundation(),
+                                                                   predicate: predicate,
                                                                    sortDescriptors: EventManagedObject.sortDescriptors,
-                                                                   context: Store.shared.managedObjectContext) as! NSFetchedResultsController<NSFetchRequestResult>
+                                                                   context: Store.shared.managedObjectContext)
         
         self.fetchedResultsController.fetchRequest.fetchBatchSize = 20
         

--- a/OpenStack Summit/OpenStackSummitTV/SpeakerSearchResultsViewController.swift
+++ b/OpenStack Summit/OpenStackSummitTV/SpeakerSearchResultsViewController.swift
@@ -48,7 +48,7 @@ final class SpeakerSearchResultsViewController: TableViewController, UISearchRes
         let summitID = SummitManager.shared.summit.value
         
         //let summitPredicate = NSPredicate(format: "%@ IN summits.id", summitID)
-        var predicate: Predicate = #keyPath(SpeakerManagedObject.summits.id).in([summitID])
+        var predicate: Predicate = (#keyPath(SpeakerManagedObject.summits.id)).in([summitID])
         
         if filterString.isEmpty == false {
             
@@ -58,11 +58,9 @@ final class SpeakerSearchResultsViewController: TableViewController, UISearchRes
             let filterPredicate: Predicate = (#keyPath(SpeakerManagedObject.firstName)).compare(.contains, [.caseInsensitive], value)
                 || (#keyPath(SpeakerManagedObject.lastName)).compare(.contains, [.caseInsensitive], value)
             
-            predicate = predicate &&
+            predicate = predicate && filterPredicate
         }
-        
-        let predicate: Predicate = predicates.count > 0 ? .compound(.and(predicates)) : predicates.first
-        
+                
         self.fetchedResultsController = NSFetchedResultsController(Speaker.self,
                                                                    delegate: self,
                                                                    predicate: predicate,

--- a/OpenStack Summit/OpenStackSummitTV/VideoSearchResultsViewController.swift
+++ b/OpenStack Summit/OpenStackSummitTV/VideoSearchResultsViewController.swift
@@ -11,6 +11,7 @@ import UIKit
 import CoreData
 import CoreSummit
 import Haneke
+import Predicate
 import func TVServices.TVTopShelfImageSize
 
 @objc(OSSTVVideoSearchResultsViewController)
@@ -53,36 +54,21 @@ final class VideoSearchResultsViewController: CollectionViewController, UISearch
         
         let sort: [NSSortDescriptor]
         
-        var predicates = [NSPredicate]()
-        
-        let summitID = NSNumber(value: Int64(SummitManager.shared.summit.value))
-        
-        let summitPredicate = NSPredicate(format: "event.summit.id == %@", summitID)
-        
-        predicates.append(summitPredicate)
+        //let summitPredicate = NSPredicate(format: "event.summit.id == %@", summitID)
+        var predicate: Predicate = #keyPath(VideoManagedObject.event.summit.id) == SummitManager.shared.summit.value
         
         if filterString.isEmpty {
             
-           sort = [NSSortDescriptor(key: "event.start", ascending: true)]
+           sort = [NSSortDescriptor(key: #keyPath(VideoManagedObject.event.start), ascending: true)]
             
         } else {
             
-            sort = [NSSortDescriptor(key: "event.name", ascending: true)]
+            sort = [NSSortDescriptor(key: #keyPath(VideoManagedObject.event.name), ascending: true)]
             
-            let filterPredicate = NSPredicate(format: "event.name CONTAINS[c] %@", filterString)
+            //let filterPredicate = NSPredicate(format: "event.name CONTAINS[c] %@", filterString)
+            let filter: Predicate = (#keyPath(VideoManagedObject.event.name)).compare(.contains, [.caseInsensitive], .value(.string(filterString)))
             
-            predicates.append(filterPredicate)
-        }
-        
-        let predicate: NSPredicate?
-        
-        if predicates.count > 0 {
-            
-            predicate = NSCompoundPredicate(andPredicateWithSubpredicates: predicates)
-            
-        } else {
-            
-            predicate = predicates.first
+            predicate = predicate && filter
         }
         
         self.fetchedResultsController = NSFetchedResultsController(Video.self,


### PR DESCRIPTION
To make app more type-safe and have some degree of compile-time error checking for fetching. 
Also fixes any errors Swift 3 migration might have created due to `Date` and other `ReferenceConvertible` value types in Foundation causing crashes when used with `NSPredicate(format:)`.